### PR TITLE
Adewyer working

### DIFF
--- a/kinbot/reaction_finder.py
+++ b/kinbot/reaction_finder.py
@@ -117,9 +117,12 @@ class ReactionFinder:
                           'R_Addition_CSm_R': self.search_R_Addition_CSm_R, 
                           'r13_insertion_RSR': self.search_r13_insertion_RSR, 
                           'beta_delta': self.search_beta_delta, 
-                          'combinatorial': self.search_combinatorial,
+                          #'combinatorial': self.search_combinatorial,
                           }
-         
+        
+        if 'combinatorial' in self.families:
+            reaction_names['combinatorial'] = self.search_combinatorial
+ 
         atom = self.species.atom
         natom = self.species.natom
        

--- a/kinbot/reaction_finder.py
+++ b/kinbot/reaction_finder.py
@@ -117,7 +117,6 @@ class ReactionFinder:
                           'R_Addition_CSm_R': self.search_R_Addition_CSm_R, 
                           'r13_insertion_RSR': self.search_r13_insertion_RSR, 
                           'beta_delta': self.search_beta_delta, 
-                          #'combinatorial': self.search_combinatorial,
                           }
         
         if 'combinatorial' in self.families:


### PR DESCRIPTION
updated reaction_finder to only do combinatorial search if 'combinatorial' is listed under the 'families' parameter.