### PR TITLE
changed exceptions in molpro.py

### DIFF
--- a/kinbot/molpro.py
+++ b/kinbot/molpro.py
@@ -11,7 +11,6 @@ class Molpro:
     def __init__(self, species, par):
         self.species = species
         self.par = par
-        # self.qc = qc
 
     def create_molpro_input(self):
         """
@@ -22,7 +21,7 @@ class Molpro:
         if self.par.par['single_point_template'] == '':
             tpl_file = pkg_resources.resource_filename('tpl', 'molpro.tpl')
         else:
-            tpl_file = self.par.par['single_point_template']  
+            tpl_file = self.par.par['single_point_template']
         with open(tpl_file) as f:
             file = f.read()
 
@@ -40,19 +39,8 @@ class Molpro:
         nelectron -= self.species.charge
 
         symm = 1
-        #TODO: Code exceptions into their own function/py script that opt can call.
-        #TODO: Fix symmetry numbers for calcs as well if needed
-        #O2
-        if self.species.chemid == "320320000000000000001": 
-            symm = 1
-            spin = 2 
-        #CH2 
-        elif self.species.chemid == "140260020000000000001": 
-            symm = 1
-            spin = 2
-        #others 
-        else: 
-            spin = self.species.mult-1
+        spin = self.species.mult - 1
+
         with open('molpro/' + fname + '.inp', 'w') as outf:
             outf.write(file.format(name=fname,
                                    natom=self.species.natom,
@@ -62,7 +50,6 @@ class Molpro:
                                    spin=spin,
                                    charge=self.species.charge
                                    ))
-
 
     def get_molpro_energy(self, key):
         """
@@ -94,37 +81,34 @@ class Molpro:
         fname = str(self.species.chemid)
         if self.species.wellorts:
             fname = self.species.name
-        
+
         # open the template head and template
-        molpro_head = pkg_resources.resource_filename('tpl', self.par.par['queuing'] + '.tpl')
+        molpro_head = pkg_resources.resource_filename(
+                'tpl',
+                self.par.par['queuing'] + '.tpl')
         with open(molpro_head) as f:
             tpl_head = f.read()
-        molpro_tpl = pkg_resources.resource_filename('tpl', self.par.par['queuing'] + '_molpro.tpl')
+        molpro_tpl = pkg_resources.resource_filename(
+                        'tpl',
+                        self.par.par['queuing'] + '_molpro.tpl')
         with open(molpro_tpl) as f:
             tpl = f.read()
         # substitution
-        with open('molpro/' + fname + '.' + self.par.par['queuing'], 'w' ) as f:
+        with open('molpro/' + fname + '.' + self.par.par['queuing'], 'w') as f:
             if self.par.par['queuing'] == 'pbs':
-                f.write((tpl_head + tpl).format(name=fname, 
-                                                ppn=self.par.par['single_point_ppn'], 
-                                                queue_name=self.par.par['queue_name'], 
-                                                dir='molpro',
-                                                command=self.par.par['single_point_command']))
+                f.write((tpl_head + tpl).format(
+                        name=fname,
+                        ppn=self.par.par['single_point_ppn'],
+                        queue_name=self.par.par['queue_name'],
+                        dir='molpro',
+                        command=self.par.par['single_point_command']))
             elif self.par.par['queuing'] == 'slurm':
-                f.write((tpl_head + tpl).format(name=fname,
-                                                ppn=self.par.par['single_point_ppn'],
-                                                queue_name=self.par.par['queue_name'],
-                                                dir='molpro',
-                                                command=self.par.par['single_point_command'],
-                                                slurm_feature=self.par.par['slurm_feature']))
-
-        #command = ['qsub', 'run_molpro.pbs']
-        #process = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
-        #out, err = process.communicate()
-        #out = out.decode()
-        #pid = out.split('\n')[0].split('.')[0]
+                f.write((tpl_head + tpl).format(
+                        name=fname,
+                        ppn=self.par.par['single_point_ppn'],
+                        queue_name=self.par.par['queue_name'],
+                        dir='molpro',
+                        command=self.par.par['single_point_command'],
+                        slurm_feature=self.par.par['slurm_feature']))
 
         return 0
-
-
-

--- a/kinbot/molpro.py
+++ b/kinbot/molpro.py
@@ -1,5 +1,6 @@
 import os
 import pkg_resources
+import numpy as np
 
 from kinbot import constants
 
@@ -114,9 +115,9 @@ class Molpro:
         return 0
 
     def molpro_symm(self):
-        if self.sepcies.atom == ['O'] and self.species.mult == 3:
+        if np.array_equal(self.species.atom, ['O']) and self.species.mult == 3:
             return 4
-        if self.species.atom == ['O', 'O'] and self.species.mult == 3:
+        if np.array_equal(self.species.atom, ['O', 'O']) and self.species.mult == 3:
             return 4
-        if sorted(self.species.atom) == sorted(['H', 'O']):
+        if np.array_equal(sorted(self.species.atom), sorted(['O', 'H'])) and self.species.mult == 3:
             return 2

--- a/kinbot/molpro.py
+++ b/kinbot/molpro.py
@@ -117,7 +117,9 @@ class Molpro:
     def molpro_symm(self):
         if np.array_equal(self.species.atom, ['O']) and self.species.mult == 3:
             return 4
-        if np.array_equal(self.species.atom, ['O', 'O']) and self.species.mult == 3:
+        if np.array_equal(self.species.atom, ['O', 'O']) \
+                and self.species.mult == 3:
             return 4
-        if np.array_equal(sorted(self.species.atom), sorted(['O', 'H'])) and self.species.mult == 3:
+        if np.array_equal(sorted(self.species.atom), sorted(['O', 'H'])) \
+                and self.species.mult == 3:
             return 2

--- a/kinbot/molpro.py
+++ b/kinbot/molpro.py
@@ -114,9 +114,9 @@ class Molpro:
         return 0
 
     def molpro_symm(self):
-        if self.sepcies.atom == ['O']:
+        if self.sepcies.atom == ['O'] and self.species.mult == 3:
             return 4
-        if self.species.atom == ['O', 'O']:
+        if self.species.atom == ['O', 'O'] and self.species.mult == 3:
             return 4
         if sorted(self.species.atom) == sorted(['H', 'O']):
             return 2

--- a/kinbot/molpro.py
+++ b/kinbot/molpro.py
@@ -38,7 +38,7 @@ class Molpro:
 
         nelectron -= self.species.charge
 
-        symm = 1
+        symm = self.molpro_symm()
         spin = self.species.mult - 1
 
         with open('molpro/' + fname + '.inp', 'w') as outf:
@@ -112,3 +112,11 @@ class Molpro:
                         slurm_feature=self.par.par['slurm_feature']))
 
         return 0
+
+    def molpro_symm(self):
+        if self.sepcies.atom == ['O']:
+            return 4
+        if self.species.atom == ['O', 'O']:
+            return 4
+        if sorted(self.species.atom) == sorted(['H', 'O']):
+            return 2

--- a/kinbot/stationary_pt.py
+++ b/kinbot/stationary_pt.py
@@ -124,7 +124,6 @@ class StationaryPoint:
                 self.dist[i][j] = np.linalg.norm(self.geom[i] - self.geom[j])
         return 0 
 
-
     def bond_mx(self):
         """ 
         Create bond matrix 
@@ -256,7 +255,6 @@ class StationaryPoint:
 
         return 0
 
-
     def make_extra_bond(self, parts, maps):
         """
         Make an extra bond between two fragments.
@@ -281,25 +279,23 @@ class StationaryPoint:
 
         return 0
 
-
     def calc_multiplicity(self, atomlist):
         """ 
-        Calculate the multiplicity based on atom types.
-        Returns the lowest multiplicity possible, i.e., singlet or dublet,
-        Gaussian style.
+        1 = singlet, 2 = doublet, 3 = triplet, etc.
         """
 
         if all([element == 'O' for element in atomlist]):
             return 3 # O and O2 are triplet
         if len(atomlist) == 1 and atomlist[0] == 'C':
-            return 3 # C atom is triplet?
+            return 3 # C atom is triplet
+        if len(atomlist) == 3 and atomlist.count('C') == 1 and atomlist.count('H') == 2:
+            return 2 # CH2
 
         mult = 0
         for element in atomlist:
             mult += constants.st_bond[element]
 
         return 1 + mult % 2
-
 
     def start_multi_molecular(self):
         """
@@ -366,7 +362,6 @@ class StationaryPoint:
 
         return mols, maps
 
-
     def extract_next_mol(self, natom, bond):
         """
         Test if a structure is bimolecular or one complex.
@@ -426,7 +421,6 @@ class StationaryPoint:
         else:
             return 0, [abs(si) for si in status]
 
-
     def find_cycle(self):
         """
         Find all the cycles in a molecule, if any
@@ -469,7 +463,6 @@ class StationaryPoint:
                             self.cycle[at] = 1
         return 0
 
-
     def calc_chemid(self):
         """ 
         The total id for a species.
@@ -488,7 +481,6 @@ class StationaryPoint:
         self.chemid += self.mult
 
         return 0
-                                                                                                
                                                                                                                         
     def start_id(self, i):
         """ 
@@ -505,10 +497,8 @@ class StationaryPoint:
         # a, visit = self.calc_atomid(visit, depth, i, atomid, natom, atom)
 
         # self.atomid[i] = a
-
         
         return 0
-                                
                                 
     def calc_atomid(self, visit, depth, i, atomid):
         """ Caclulate chemical ID for a given atom. """        
@@ -535,7 +525,6 @@ class StationaryPoint:
 
         return atomid, visit
 
-    
     def find_dihedral(self): 
         """ 
         Identify unique rotatable bonds in the structure 
@@ -571,7 +560,6 @@ class StationaryPoint:
 
         return 0
 
-
     def find_conf_dihedral(self):
         """
         Just keep those rotatable bonds that are needed for conformer search.
@@ -598,7 +586,6 @@ class StationaryPoint:
                     elif self.atomid[i] != base: 
                         dihed_sideb.append(self.dihed[rotbond][:])
                         break
-                
                         
         for rotbond in range(len(self.dihed)):
             start = 0
@@ -619,7 +606,6 @@ class StationaryPoint:
                 if dihed_sideb[b] == dihed_sidec[c]: self.conf_dihed.append(dihed_sideb[b][:])
                 
         return 0
-                
                 
     def find_atom_eqv(self):
         """
@@ -643,7 +629,6 @@ class StationaryPoint:
                 self.atom_eqv.append([atomi])
         
         return 0
-
 
     def rigid_along_path(self,atomi, atomj):
         """
@@ -677,7 +662,6 @@ class StationaryPoint:
                                     return 1
                     return 0
         return 0
-
 
 def main():
     """


### PR DESCRIPTION
The spin exceptions were already in stationary.py, so I updated those. 
```
    def calc_multiplicity(self, atomlist):
        """ 
        1 = singlet, 2 = doublet, 3 = triplet, etc.
        """

        if all([element == 'O' for element in atomlist]):
            return 3 # O and O2 are triplet
        if len(atomlist) == 1 and atomlist[0] == 'C':
            return 3 # C atom is triplet
        if len(atomlist) == 3 and atomlist.count('C') == 1 and atomlist.count('H') == 2:
            return 2 # CH2

        mult = 0
        for element in atomlist:
            mult += constants.st_bond[element]

        return 1 + mult % 2
```
molpro.py only needs to care of the orbital symmetry. It was overwriting before that in fact to the wrong value. 
```
    def molpro_symm(self):
        if np.array_equal(self.species.atom, ['O']) and self.species.mult == 3:
            return 4
        if np.array_equal(self.species.atom, ['O', 'O']) and self.species.mult == 3:
            return 4
        if np.array_equal(sorted(self.species.atom), sorted(['O', 'H'])) and self.species.mult == 3:
            return 2
```
flake8 for molpro.py