### PR TITLE
Ion fragmentation and flat_ring_dih_angle

### DIFF
--- a/kinbot/conformers.py
+++ b/kinbot/conformers.py
@@ -89,6 +89,7 @@ class Conformers:
         self.db = connect('kinbot.db')
 
         self.imagfreq_threshold = par['imagfreq_threshold']
+        self.flat_ring_dih_angle = par['flat_ring_dih_angle']
 
     def generate_ring_conformers(self, cart):
         """
@@ -112,7 +113,7 @@ class Conformers:
                 for dih in dihs:
                     val = geometry.calc_dihedral(cart[dih[0]], cart[dih[1]],
                                                  cart[dih[2]], cart[dih[3]])[0]
-                    if abs(val) < 5.:
+                    if abs(val) < self.flat_ring_dih_angle:
                         flat_ring_dih.append(True)
                     else:
                         flat_ring_dih.append(False)

--- a/kinbot/molpro.py
+++ b/kinbot/molpro.py
@@ -133,6 +133,8 @@ class Molpro:
         """
         fname = self.get_name(name)
         status = os.path.exists('molpro/' + fname + '.out')
+        if fname == '10000000000000000001':  # proton
+            return 1, 0.0
         if status:
             with open('molpro/' + fname + '.out') as f:
                 lines = f.readlines()

--- a/kinbot/parameters.py
+++ b/kinbot/parameters.py
@@ -118,6 +118,8 @@ class Parameters:
             'max_dihed': 5,
             # Number of random conformers in case no exhaustive search is done
             'random_conf': 500,
+            # Dihedral angle to consider a section of a ring flat
+            'flat_ring_dih_angle': 5.,
             # Maximum number of diherals for which exhaustive
             # comformation searches are done at semi empirical level
             'max_dihed_semi_emp': 5,

--- a/kinbot/pes.py
+++ b/kinbot/pes.py
@@ -1364,6 +1364,8 @@ def get_l3energy(job, par, bls=0):
     else:
         key = par['single_point_key']
 
+    if job == '10000000000000000001':  # proton
+        return 1, 0.0
     if par['single_point_qc'] == 'molpro':
         if os.path.exists(f'molpro/{job}.out'):
             with open(f'molpro/{job}.out', 'r') as f:

--- a/kinbot/stationary_pt.py
+++ b/kinbot/stationary_pt.py
@@ -434,7 +434,7 @@ class StationaryPoint:
                 natomi = np.sum(fragi)
                 atomi = atomlist[np.where(np.asarray(fragi) == 1)]
 
-                if vary_charge and charge != 0:
+                if vary_charge and self.charge != 0:
                     multiply = 2
                 else:
                     multiply = 1

--- a/kinbot/stationary_pt.py
+++ b/kinbot/stationary_pt.py
@@ -434,7 +434,7 @@ class StationaryPoint:
                 natomi = np.sum(fragi)
                 atomi = atomlist[np.where(np.asarray(fragi) == 1)]
 
-                if vary_charge:
+                if vary_charge and charge != 0:
                     multiply = 2
                 else:
                     multiply = 1


### PR DESCRIPTION
I added a new parameter: `flat_ring_dih_angle`, which allows the user to define what ring is flat. The default is 5 degrees, the old, hard-wired value. The problem was that this was too small for some systems and we generated way too many conformers.

More importantly, I added a way to deal with ion fragmentation. We now generate all possible versions of the fragments that are consistent with the overall charge and their own multiplicity. Then, we brute force take all combinations of all fragments, and select the lowest energy combination that is consistent with overall mass and charge. This approach eliminates tedious bookkeeping, because some fragments repeat and some fragments fragment further, sometimes even twice. Therefore, it is not possible to select the viable combinations based on indices alone, at least not simply. This solution had very little impact on the overall workflow. Note that at this point we are only considering singlets and doublets, but not triplets. We can add that as well in this scheme though.