### PR TITLE
Drop the Sella IRC shim, require sella>=2.6.0

### DIFF
--- a/kinbot/tpl/ase_fc_irc.tpl.py
+++ b/kinbot/tpl/ase_fc_irc.tpl.py
@@ -6,18 +6,11 @@ import shutil
 from ase import Atoms
 from ase.io import read, write
 
-from sella import Sella, IRC as SellaIRC
+from sella import Sella, IRC
 
 from fairchem.core import FAIRChemCalculator
 from kinbot.fairchem_utils import load_predictor
 from kinbot.frequencies import calc_vibrations
-
-
-class IRC(SellaIRC):
-    """Keep Sella's first-step guard with ASE 3.28 and newer."""
-
-    def gradient_converged(self, gradient=None):
-        return self.converged()
 
 
 if os.path.isfile('{label}_sella.log'):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
         "ase>=3.26",
         "networkx",
         "rmsd>=1.5.1",
-        "sella>=2.5.0"
+        "sella>=2.6.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
The `gradient_converged` workaround in `ase_fc_irc.tpl.py` subclassed Sella's `IRC` to restore the first-step guard that ASE >= 3.28 broke. That fix is now released upstream in **sella 2.6.0** (zadorlab/sella#83), so the local override is redundant and would shadow any later upstream refinement.

Bumping the requirement also fixes `ase_sella_irc.tpl.py`, which imports `sella.IRC` directly and was never covered by the shim -- that path was broken on ASE >= 3.28 and is fixed here with no edit to the file.

Follow-up to #90.

### Changes
- `pyproject.toml`: `sella>=2.5.0` -> `sella>=2.6.0`
- `kinbot/tpl/ase_fc_irc.tpl.py`: remove the `IRC(SellaIRC)` subclass, restore `from sella import Sella, IRC`

### Notes
sella 2.6.0 raises its own floor from `ase>=3.18.0` to `ase>=3.26.0`. KinBot already requires `ase>=3.26`, which is the same requirement under PEP 440, so no change was needed there. jax/jaxlib were already sella dependencies in 2.5.0 -- nothing new enters the tree.

### Verification
- `gradient_converged` confirmed present in the published 2.6.0 sdist on PyPI, not just on sella master
- `git grep SellaIRC` returns nothing
- template renders and byte-compiles with all 11 placeholders substituted
