### PR TITLE
Mechanical fixes from #92 (A/4)

### DIFF
--- a/kinbot/cheminfo.py
+++ b/kinbot/cheminfo.py
@@ -33,8 +33,10 @@ def get_molecular_formula(smi):
     Return the molecular formula of the molecule corresponding to the smiles
     """
     try:
+        from rdkit import Chem
+        from rdkit.Chem import rdMolDescriptors
         mol = Chem.AddHs(Chem.MolFromSmiles(smi))
-    except NameError:
+    except ImportError:
         logger.error('RDKit is not installed or loaded correctly.')
         sys.exit()
     return rdMolDescriptors.CalcMolFormula(mol)
@@ -117,8 +119,10 @@ def generate_3d_structure(smi, obabel=1):
         return obmol, structure, bond
     else:  # use RDKit
         try:
+            from rdkit import Chem
+            from rdkit.Chem import AllChem
             rdmol = Chem.AddHs(Chem.MolFromSmiles(smi))
-        except NameError:
+        except ImportError:
             logger.error('RDKit is not installed or loaded correctly.')
             sys.exit()
         AllChem.EmbedMolecule(rdmol, AllChem.ETKDG())
@@ -249,5 +253,4 @@ def create_smiles(inchi):
 def create_smi_from_geom(atom, geom):
     inchi = create_inchi_from_geom(atom, geom)
     return create_smiles(inchi)
-
 

--- a/kinbot/cheminfo.py
+++ b/kinbot/cheminfo.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import logging
+from contextlib import ExitStack
 
 import numpy as np
 from PIL import Image
@@ -65,21 +66,22 @@ def create_rxn_depiction(react_smiles, prod_smiles, cdir, name):
     obmol.draw(show=False, filename=prod_png)
 
     arrow = f'{kb_path}/tpl/arrow.png'
-    images = map(Image.open, [react_png, arrow, prod_png])
-    widths, heights = zip(*(i.size for i in images))
+    with ExitStack() as stack:
+        images = [stack.enter_context(Image.open(path))
+                  for path in (react_png, arrow, prod_png)]
+        widths, heights = zip(*(i.size for i in images))
 
-    total_width = sum(widths)
-    total_height = max(heights)
+        total_width = sum(widths)
+        total_height = max(heights)
 
-    new_im = Image.new('RGB', (total_width, total_height), (255, 255, 255))
+        with Image.new('RGB', (total_width, total_height), (255, 255, 255)) as new_im:
+            x = 0
+            for im in images:
+                y = (total_height - im.size[1]) // 2
+                new_im.paste(im, (x, y))
+                x += im.size[0]
 
-    x = 0
-    for im in images:
-        y = total_height / 2 - im.size[1] / 2
-        new_im.paste(im, (x, y))
-        x += im.size[0]
-
-    new_im.save(f'{cdir}/{name}.png')
+            new_im.save(f'{cdir}/{name}.png')
 
 
 def generate_3d_structure(smi, obabel=1):
@@ -253,4 +255,3 @@ def create_smiles(inchi):
 def create_smi_from_geom(atom, geom):
     inchi = create_inchi_from_geom(atom, geom)
     return create_smiles(inchi)
-

--- a/kinbot/frequencies.py
+++ b/kinbot/frequencies.py
@@ -276,10 +276,10 @@ def calc_vibrations(mol, label):
         os.mkdir(f'{label}_vib')
     init_dir = os.getcwd()
     os.chdir(f'{label}_vib')
-    if os.path.isdir('vib'):
-        shutil.rmtree('vib')
-    vib = Vibrations(mol)
     try:
+        if os.path.isdir('vib'):
+            shutil.rmtree('vib')
+        vib = Vibrations(mol)
         vib.run()
         vib.write_jmol()
         # Use kinbot frequencies to avoid mixing low vib frequencies with 
@@ -290,7 +290,8 @@ def calc_vibrations(mol, label):
         st_pt = StationaryPoint.from_ase_atoms(mol)
         st_pt.characterize()
         freqs, _ = get_frequencies(st_pt, hessian, st_pt.geom)
-        os.chdir(init_dir)
         return freqs, zpe, hessian
-    except:
+    except Exception:
         return None, None, None
+    finally:
+        os.chdir(init_dir)

--- a/kinbot/hindered_rotors.py
+++ b/kinbot/hindered_rotors.py
@@ -213,7 +213,7 @@ class HIR:
                 for j, at in enumerate(self.species.atom):
                     x, y, z = self.hir_geoms[rotor][i][j]
                     s += '{} {:.8f} {:.8f} {:.8f}\n'.format(at, x, y, z)
-            ff.write(s)
+                ff.write(s)
         return
 
     def fourier_fit(self, job, angles, rotor):

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -340,10 +340,7 @@ class Optimize:
                         and not self.just_high:
                     fr_file = self.log_name(self.par['high_level'])
                     hess = self.qc.read_qc_hess(fr_file, self.species.natom)
-                    if self.qc.qc == 'qchem':
-                        massweighted = True
-                    else:
-                        massweighted = False
+                    massweighted = self.qc.hessian_is_massweighted()
                     self.species.kinbot_freqs, self.species.reduced_freqs = frequencies.get_frequencies(self.species, 
                                                                                                         hess, 
                                                                                                         self.species.geom, 

--- a/kinbot/parameters.py
+++ b/kinbot/parameters.py
@@ -473,7 +473,8 @@ class Parameters:
                                'energies are not guaranteed to belong to the '
                                'lowest conformer.')
 
-        if self.par['high_level'] == 0 and self.par['rotor_scan'] == 1:
+        if (self.par['high_level'] == 0 and self.par['rotor_scan'] == 1
+                and self.par['qc'].lower() != 'fc'):
             if show_warnings:
                 logger.warning('L1 level of theory (here set to '
                                f'{self.par["method"].upper()}/{self.par["basis"].upper()}) is '
@@ -500,7 +501,8 @@ class Parameters:
         if self.par['uq'] == 0:
             self.par['uq_n'] = 1
 
-        if self.par['bimol'] == 1 and self.par['method'] == 'b3lyp':
+        if (self.par['bimol'] == 1 and self.par['method'] == 'b3lyp'
+                and self.par['qc'].lower() != 'fc'):
             logger.warning('B3LYP is not recommended as L1 for bimolecular reactions.')
             logger.warning('Choose for instance M06-2X or wB97XD.')
             print('B3LYP is not recommended as L1 for bimolecular reactions.')

--- a/kinbot/qc.py
+++ b/kinbot/qc.py
@@ -821,7 +821,7 @@ class QuantumChemistry:
 
         job = f'vrctst/{str(frag.chemid)}_vts'
         mult = exceptions.get_multiplicity(frag.chemid, frag.mult)
-        kwargs = self.get_qc_arguments(job, mult, frag.charge, species.nel, vts=1)
+        kwargs = self.get_qc_arguments(job, mult, frag.charge, frag.nel, vts=1)
         # Add chk to fragments only
         kwargs['chk'] = f'{str(frag.chemid)}_vts'
 
@@ -846,7 +846,7 @@ class QuantumChemistry:
         with open(f'{job}.py', 'w') as f:
             f.write(template)
 
-        self.submit_qc(job, min(species.nel, self.ppn))
+        self.submit_qc(job, min(frag.nel, self.ppn))
         
         return job 
 
@@ -861,7 +861,7 @@ class QuantumChemistry:
         else:
             job = f'vrctst/{reac.instance_name}_vts_pt_asymptote'
         mult = exceptions.get_multiplicity(reac.species.chemid, reac.species.mult)
-        kwargs = self.get_qc_arguments(job, mult, reac.species.charge, species.nel, vts=1)
+        kwargs = self.get_qc_arguments(job, mult, reac.species.charge, reac.species.nel, vts=1)
 
         if self.qc == 'gauss' and not self.par['vrc_tst_scan_sella']:
             kwargs['addsec'] = f'{reac.scan_coo[0]+1} {reac.scan_coo[1]+1} F\n'
@@ -927,7 +927,7 @@ class QuantumChemistry:
         with open(f'{job}.py', 'w') as f:
             f.write(template)
 
-        self.submit_qc(job, min(species.nel, self.ppn))
+        self.submit_qc(job, min(reac.species.nel, self.ppn))
         return job 
 
     def submit_qc(self, job, nproc, singlejob=1, jobtype=None):

--- a/kinbot/qc.py
+++ b/kinbot/qc.py
@@ -1224,6 +1224,10 @@ class QuantumChemistry:
 
         return 0, zpe
 
+    def hessian_is_massweighted(self):
+        """Native QChem Hessians are weighted; ASE/Sella Hessians are not."""
+        return self.qc == 'qchem' and not self.use_sella
+
     def read_qc_hess(self, job, natom):
         '''
         Read the hessian of a gaussian chk file

--- a/kinbot/qc.py
+++ b/kinbot/qc.py
@@ -997,7 +997,7 @@ class QuantumChemistry:
                 job_template += '\ncp -r $SCRATCH_DIR/* $SLURM_SUBMIT_DIR/hir/.\ncd /scratch/$USER\nrm -rf $SCRATCH_DIR'
 
         if self.queuing == 'pbs':
-            job_template = job_template.format(name=job, ppn=max(1, proc), queue_name=self.queue_name,
+            job_template = job_template.format(name=job, ppn=max(1, nproc), queue_name=self.queue_name,
                                                errdir='perm', python_file=python_file, arguments='')
         elif self.queuing == 'slurm':
             job_template = job_template.format(name=job, ppn=max(1, nproc), queue_name=self.queue_name, errdir='perm',

--- a/tests/test_cheminfo_regressions.py
+++ b/tests/test_cheminfo_regressions.py
@@ -1,0 +1,29 @@
+"""Regression tests for optional chemistry helpers and reaction images."""
+
+import importlib.util
+import unittest
+
+import numpy as np
+
+from kinbot import cheminfo
+
+
+@unittest.skipUnless(importlib.util.find_spec('rdkit'), 'RDKit is optional')
+class TestRDKitHelpers(unittest.TestCase):
+    def test_molecular_formula_loads_rdkit_locally(self):
+        self.assertEqual(cheminfo.get_molecular_formula('C=O'), 'CH2O')
+
+    def test_rdkit_structure_contains_coordinates_and_bonds(self):
+        molecule, structure, bond = cheminfo.generate_3d_structure('CO', obabel=0)
+        self.assertEqual(molecule.GetNumAtoms(), 6)
+        self.assertEqual(len(structure), 24)
+        self.assertEqual(sorted(structure[::4]), ['C', 'H', 'H', 'H', 'H', 'O'])
+        coordinates = np.asarray([structure[i + 1:i + 4] for i in range(0, 24, 4)])
+        self.assertTrue(np.isfinite(coordinates).all())
+        self.assertGreater(np.linalg.norm(coordinates[0] - coordinates[1]), 0.5)
+        np.testing.assert_array_equal(bond, bond.T)
+        self.assertEqual(np.count_nonzero(bond), 10)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cheminfo_regressions.py
+++ b/tests/test_cheminfo_regressions.py
@@ -1,9 +1,14 @@
 """Regression tests for optional chemistry helpers and reaction images."""
 
 import importlib.util
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 import unittest
+from unittest.mock import patch
 
 import numpy as np
+from PIL import Image
 
 from kinbot import cheminfo
 
@@ -23,6 +28,35 @@ class TestRDKitHelpers(unittest.TestCase):
         self.assertGreater(np.linalg.norm(coordinates[0] - coordinates[1]), 0.5)
         np.testing.assert_array_equal(bond, bond.T)
         self.assertEqual(np.count_nonzero(bond), 10)
+
+
+class TestReactionDepiction(unittest.TestCase):
+    def test_reactant_arrow_and_product_are_pasted_in_order(self):
+        with TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / 'tpl').mkdir()
+            with Image.new('RGB', (3, 5), 'green') as arrow:
+                arrow.save(root / 'tpl/arrow.png')
+
+            def readstring(kind, smiles):
+                size, color = ((2, 3), 'red') if smiles == 'C' else ((4, 7), 'blue')
+
+                def draw(show, filename):
+                    with Image.new('RGB', size, color) as panel:
+                        panel.save(filename)
+
+                return SimpleNamespace(draw=draw)
+
+            with patch.object(cheminfo, 'kb_path', directory), \
+                    patch.object(cheminfo, 'pybel', SimpleNamespace(readstring=readstring), create=True):
+                cheminfo.create_rxn_depiction('C', 'CO', directory, 'reaction')
+
+            with Image.open(root / 'reaction.png') as result:
+                self.assertEqual(result.size, (9, 7))
+                self.assertEqual(result.getpixel((0, 2)), (255, 0, 0))
+                self.assertEqual(result.getpixel((2, 1)), (0, 128, 0))
+                self.assertEqual(result.getpixel((5, 0)), (0, 0, 255))
+                self.assertEqual(result.getpixel((0, 0)), (255, 255, 255))
 
 
 if __name__ == '__main__':

--- a/tests/test_hessian_provenance.py
+++ b/tests/test_hessian_provenance.py
@@ -1,0 +1,66 @@
+"""Check that native QChem and ASE Hessians produce the same frequencies."""
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+import unittest
+
+from ase.build import molecule
+import numpy as np
+
+from kinbot import constants, frequencies
+from kinbot.optimize import Optimize
+from kinbot.qc import QuantumChemistry
+from kinbot.stationary_pt import StationaryPoint
+
+
+class TestHessianWeighting(unittest.TestCase):
+    def test_native_and_sella_qchem_results_project_identically(self):
+        with TemporaryDirectory() as directory:
+            previous = Path.cwd()
+            try:
+                os.chdir(directory)
+                atoms = molecule('H2O')
+                point = StationaryPoint('water', 0, 1,
+                                        atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+                point.characterize()
+                hessian = np.diag(np.arange(1., 10.))
+                masses = np.repeat([constants.exact_mass[atom] for atom in point.atom], 3)
+                weighted = hessian / np.sqrt(np.outer(masses, masses))
+                with open('audit_freq.out', 'w') as handle:
+                    handle.write(' Mass-Weighted Hessian Matrix\n')
+                    np.savetxt(handle, weighted)
+                    handle.write(' Translations and Rotations\n')
+                expected, _ = frequencies.get_frequencies(point, hessian, point.geom)
+
+                for use_sella in (False, True):
+                    with self.subTest(use_sella=use_sella):
+                        qc = QuantumChemistry.__new__(QuantumChemistry)
+                        qc.qc = 'qchem'
+                        qc.use_sella = use_sella
+                        qc.check_qc = lambda job: 'normal'
+                        qc.db = SimpleNamespace(select=lambda **kw: [
+                            SimpleNamespace(data={'hess': hessian})])
+                        optimization = Optimize.__new__(Optimize)
+                        optimization.species = point
+                        optimization.qc = qc
+                        optimization.par = {
+                            'conformer_search': 0, 'rotation_restart': -1,
+                            'high_level': 0, 'rotor_scan': 1,
+                            'multi_conf_tst': 0, 'L3_calc': 0,
+                        }
+                        optimization.shir = 1
+                        optimization.restart = 0
+                        optimization.just_high = False
+                        optimization.defer_hir = False
+                        optimization.wait = 0
+                        optimization.log_name = lambda level: 'audit'
+                        optimization.do_optimization()
+                        np.testing.assert_allclose(point.reduced_freqs, expected, rtol=1.e-8)
+            finally:
+                os.chdir(previous)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -1,0 +1,46 @@
+"""Regression tests for hindered-rotor results, without QC calculations."""
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+import unittest
+
+from ase.io import read
+import numpy as np
+
+from kinbot.hindered_rotors import HIR
+
+
+class TestHIRProfile(unittest.TestCase):
+    def test_combined_xyz_contains_every_scan_point(self):
+        with TemporaryDirectory() as directory:
+            previous = Path.cwd()
+            try:
+                os.chdir(directory)
+                Path('hir').mkdir()
+                species = SimpleNamespace(natom=2, atom=['C', 'H'])
+                hir = HIR(species, None, {
+                    'nrotation': 3, 'plot_hir_profiles': False,
+                    'rotor_0_test': True,
+                })
+                geometries = np.arange(18, dtype=float).reshape(3, 2, 3) / 10
+                energies = [-40.0, -39.99, -39.98]
+                hir.hir_geoms = [geometries]
+                hir.hir_energies = [energies]
+
+                hir.write_profile(0, 'profile')
+
+                frames = read('hir/profile.xyz', index=':', format='xyz')
+                self.assertEqual(len(frames), 3)
+                for frame, positions in zip(frames, geometries):
+                    self.assertEqual(frame.get_chemical_symbols(), ['C', 'H'])
+                    np.testing.assert_allclose(frame.positions, positions)
+                comments = Path('hir/profile.xyz').read_text().splitlines()[1::4]
+                self.assertEqual(comments, [f'energy = {e}' for e in energies])
+            finally:
+                os.chdir(previous)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,0 +1,52 @@
+"""Backend-aware input validation regressions."""
+
+from contextlib import redirect_stdout
+import io
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import patch
+
+from kinbot.parameters import Parameters
+
+
+class TestBackendWarnings(unittest.TestCase):
+    def read_parameters(self, **options):
+        with TemporaryDirectory() as directory:
+            input_file = Path(directory) / 'input.json'
+            input_file.write_text(json.dumps({
+                'barrier_threshold': 50.,
+                'sella_kwargs': {'internal': True, 'gamma': 0.},
+                **options,
+            }))
+            return Parameters(str(input_file), show_warnings=True).par
+
+    def test_fairchem_rotors_ignore_unused_method_and_basis(self):
+        with patch('kinbot.parameters.logger.warning') as warning:
+            par = self.read_parameters(qc='fc', fc_model_path='uma-m-1p1',
+                                       rotor_scan=1)
+        self.assertEqual(par['rotor_scan'], 1)
+        warning.assert_not_called()
+
+    def test_conventional_rotors_still_require_matching_levels(self):
+        with self.assertRaises(SystemExit):
+            self.read_parameters(qc='gauss', rotor_scan=1)
+        with patch('kinbot.parameters.logger.warning') as warning:
+            self.read_parameters(qc='gauss', rotor_scan=1,
+                                 high_level_method='B3LYP', high_level_basis='6-31G')
+        self.assertIn('B3LYP/6-31G', str(warning.call_args))
+
+    def test_bimolecular_method_warning_uses_the_actual_backend(self):
+        for backend in ['fc', 'gauss']:
+            with self.subTest(backend=backend), redirect_stdout(io.StringIO()) as output:
+                with patch('kinbot.parameters.logger.warning') as warning:
+                    self.read_parameters(qc=backend, fc_model_path='uma-m-1p1',
+                                         bimol=1, structure=[['H', 0., 0., 0.]] * 2)
+                self.assertEqual('B3LYP is not recommended' in output.getvalue(),
+                                 backend == 'gauss')
+                self.assertEqual(warning.called, backend == 'gauss')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_qc_jobs.py
+++ b/tests/test_qc_jobs.py
@@ -1,5 +1,6 @@
 """Job-writing regressions with all scheduler submission mocked out."""
 
+import ast
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -35,6 +36,53 @@ class TestSchedulerJobs(unittest.TestCase):
                 self.assertEqual(qc.job_ids, {'test_job': '123'})
                 self.assertEqual(result, 1)
                 self.assertEqual(submit.call_args.args[0], ['qsub', 'test_job.pbs'])
+
+
+class TestVRCJobs(unittest.TestCase):
+    def setUp(self):
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.addCleanup(os.chdir, Path.cwd())
+        os.chdir(temporary.name)
+        Path('vrctst').mkdir()
+        self.qc = SimpleNamespace(
+            qc='gauss', qc_command='g16', ppn=8,
+            par={'calc_kwargs': {}, 'vrc_tst_scan_sella': False,
+                 'vrc_tst_scan_deviation': 0.1, 'vts_ang_dev': 10,
+                 'sella_kwargs': {}},
+            get_qc_arguments=Mock(return_value={}), submit_qc=Mock(),
+        )
+        self.fragment = SimpleNamespace(
+            chemid=1, charge=0, mult=2, nel=1, natom=1,
+            atom=['H'], geom=[[0., 0., 0.]], bond01=[[0]],
+        )
+
+    def test_fragment_job_uses_fragment_electron_count(self):
+        job = QuantumChemistry.qc_vts_frag(self.qc, self.fragment)
+        self.qc.get_qc_arguments.assert_called_once_with(job, 2, 0, 1, vts=1)
+        self.qc.submit_qc.assert_called_once_with(job, 1)
+        ast.parse(Path(f'{job}.py').read_text())
+
+    def test_scan_jobs_use_reacting_species_electron_count(self):
+        species = SimpleNamespace(
+            chemid=2, charge=0, mult=1, nel=2, natom=2,
+            atom=['H', 'H'], geom=[[0., 0., 0.], [1., 0., 0.]],
+        )
+        reaction = SimpleNamespace(
+            species=species, instance_name='reaction', scan_coo=[0, 1],
+            irc_prod=SimpleNamespace(bondlist=[]), maps=[[0], [1]],
+            products=[self.fragment, self.fragment],
+        )
+        for sella, asymptote in ((False, False), (True, False), (True, True)):
+            with self.subTest(sella=sella, asymptote=asymptote):
+                self.qc.par['vrc_tst_scan_sella'] = sella
+                self.qc.get_qc_arguments.reset_mock()
+                self.qc.submit_qc.reset_mock()
+                job = QuantumChemistry.qc_vts(
+                    self.qc, reaction, species.geom, 0, [], asymptote, species.geom)
+                self.qc.get_qc_arguments.assert_called_once_with(job, 1, 0, 2, vts=1)
+                self.qc.submit_qc.assert_called_once_with(job, 2)
+                ast.parse(Path(f'{job}.py').read_text())
 
 
 if __name__ == '__main__':

--- a/tests/test_qc_jobs.py
+++ b/tests/test_qc_jobs.py
@@ -1,0 +1,41 @@
+"""Job-writing regressions with all scheduler submission mocked out."""
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+from kinbot.qc import QuantumChemistry
+
+
+class TestSchedulerJobs(unittest.TestCase):
+    def setUp(self):
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.addCleanup(os.chdir, Path.cwd())
+        os.chdir(temporary.name)
+
+    def test_pbs_uses_requested_processors_and_records_job_id(self):
+        for requested, expected in ((4, 4), (0, 1)):
+            with self.subTest(requested=requested):
+                qc = SimpleNamespace(
+                    check_qc=lambda job: 0, queue_job_limit=0,
+                    par={'queue_template': ''}, queuing='pbs', qc='gauss',
+                    queue_name='test', job_ids={},
+                )
+                process = Mock()
+                process.communicate.return_value = (b'123.server\n', b'')
+                with patch('kinbot.qc.subprocess.Popen', return_value=process) as submit:
+                    result = QuantumChemistry.submit_qc(qc, 'test_job', requested)
+                script = Path('test_job.pbs').read_text()
+                self.assertIn(f'nodes=1:ppn={expected}', script)
+                self.assertIn(f'OMP_NUM_THREADS={expected}', script)
+                self.assertEqual(qc.job_ids, {'test_job': '123'})
+                self.assertEqual(result, 1)
+                self.assertEqual(submit.call_args.args[0], ['qsub', 'test_job.pbs'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_vibrations.py
+++ b/tests/test_vibrations.py
@@ -1,0 +1,52 @@
+"""Failure-path regressions for ASE vibration calculations."""
+
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock, patch
+
+import numpy as np
+
+from kinbot import frequencies
+
+
+class TestVibrationWorkingDirectory(unittest.TestCase):
+    def setUp(self):
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.addCleanup(os.chdir, Path.cwd())
+        os.chdir(temporary.name)
+        self.directory = Path.cwd()
+        self.molecule = SimpleNamespace(calc=SimpleNamespace(parameters={}))
+
+    def test_failure_restores_working_directory(self):
+        for stage in ('construction', 'run', 'write_jmol'):
+            with self.subTest(stage=stage):
+                os.chdir(self.directory)
+                vibrations = Mock()
+                constructor = Mock(return_value=vibrations)
+                target = constructor if stage == 'construction' else getattr(vibrations, stage)
+                target.side_effect = RuntimeError('deliberate vibration failure')
+                with patch.object(frequencies, 'Vibrations', constructor):
+                    result = frequencies.calc_vibrations(self.molecule, stage)
+                self.assertEqual(result, (None, None, None))
+                self.assertEqual(Path.cwd(), self.directory)
+
+    def test_success_restores_directory_and_preserves_results(self):
+        vibrations = Mock(H=np.eye(9))
+        vibrations.get_zero_point_energy.return_value = 0.5
+        point = Mock(geom=np.zeros((3, 3)))
+        with patch.object(frequencies, 'Vibrations', return_value=vibrations), \
+                patch.object(frequencies.StationaryPoint, 'from_ase_atoms', return_value=point), \
+                patch.object(frequencies, 'get_frequencies', return_value=([100., 200., 300.], [])):
+            freq, zpe, hess = frequencies.calc_vibrations(self.molecule, 'success')
+        self.assertEqual(Path.cwd(), self.directory)
+        self.assertEqual(freq, [100., 200., 300.])
+        self.assertEqual(zpe, 0.5 * frequencies.EVtoHARTREE)
+        np.testing.assert_allclose(hess, np.eye(9) / 97.17370087)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Mechanical fixes split out of #92 (part A of 4). Cherry-picked verbatim from `kinbot-bugfix` with original authorship; each commit carries its own test. None of these change numerical results — every one fixes code that either could not run or produced no usable output.

| Commit | Fix |
|---|---|
| Write every scan geometry to combined HIR XYZ profiles | `hir/*.xyz` held only the last scan point: `s` was rebuilt each iteration and written once after the loop. |
| Restore the working directory after failed ASE vibration calculations | Any exception in `calc_vibrations` left the process inside `<label>_vib/`. Now `try/finally`; bare `except:` → `except Exception:`. |
| Use the requested processor count when generating PBS jobs | `ppn=max(1, proc)` — `proc` is undefined in `submit_qc`; every PBS submission raised `NameError`. |
| Use fragment and reactant electron counts in VRC job writers | `qc_vts_frag` / `qc_vts` referenced `species.nel` with no `species` in scope. |
| Import optional RDKit helpers where formula and geometry functions use them | `Chem` was never imported at module scope, so `get_molecular_formula` and the RDKit branch of `generate_3d_structure` always hit `except NameError` → `sys.exit()`. |
| Render all panels in reaction depictions instead of a blank image | `map()` iterator consumed by the size `zip`, so the paste loop ran over nothing; float paste coords also rejected by current Pillow. |
| Skip conventional method and basis checks for FairChem calculations | L1-rotor and B3LYP warnings keyed off method/basis strings that FairChem does not use. |
| Distinguish native QChem Hessians from unweighted Sella Hessians | qchem + Sella yields an unweighted Hessian but was treated as mass-weighted. New `QuantumChemistry.hessian_is_massweighted()`. |

Follow-ups from #92 land separately:
- **B** — HIR correctness (`is_valid_rotor`, per-rotor Fourier coefficients, restart reference). Blocked on a `make_rotors` ordering fix: `species.hir` is `None` for `just_high` species.
- **C** — conformers (ZPE double count in Boltzmann screening; L0 search plumbing, whose no-valid-conformer fallback needs to call `generate_conformers(0, …)`).
- **D** — `semi_emp_*` → `L0_*` input rename, or drop it.

Tests: `python -m unittest tests.test_hindered_rotors tests.test_vibrations tests.test_qc_jobs tests.test_cheminfo_regressions tests.test_parameters tests.test_hessian_provenance` → 13 passed, 2 skipped (RDKit optional). Full `tests/` discovery matches the `master` baseline (17 errors / 1 failure, all pre-existing pybel/RDKit import errors).