### PR TITLE
HIR fixes from #92 (B/4)

### DIFF
--- a/kinbot/frequencies.py
+++ b/kinbot/frequencies.py
@@ -122,7 +122,10 @@ def get_frequencies(species, hess, geom, checkdist=0, massweighted=False):
 
     # Build set of internal rotation vectors to project out
     R = []
-    for rot in species.dihed:
+    for rotor, rot in enumerate(species.dihed):
+        hir = getattr(species, 'hir', None)
+        if hir is not None and not hir.is_valid_rotor(rotor):
+            continue
         if skip_rotor(species.name, rot) == 1:
             continue
             

--- a/kinbot/hindered_rotors.py
+++ b/kinbot/hindered_rotors.py
@@ -150,17 +150,43 @@ class HIR:
 
         return 0
 
+    def invalid_rotor_reason(self, rotor):
+        """Why a rotor is excluded from the hindered-rotor treatment.
+
+        Returns None for a usable scan. Failed non-reference points retain
+        the existing Fourier-fill policy and do not make a rotor invalid.
+        """
+        if rotor >= len(self.hir_status) or len(self.hir_status[rotor]) != self.nrotation:
+            return 'no scan recorded'
+        status = self.hir_status[rotor]
+        if status[0] == 2:
+            return 'scan skipped'
+        if status[0] == 1:
+            return 'reference point failed or scans disabled by the rotor-0 energy test'
+        if any(value < 0 for value in status):
+            return 'scan incomplete'
+        return None
+
     def is_valid_rotor(self, rotor):
         """Whether a completed scan has a usable reference point.
 
-        Failed non-reference points retain the existing Fourier-fill policy.
-        Completion alone does not enable a failed or skipped rotor.
+        Completion alone does not enable a failed or skipped rotor; such
+        rotors stay harmonic oscillators in the frequency set and in MESS.
         """
-        if rotor >= len(self.hir_status):
-            return False
-        status = self.hir_status[rotor]
-        return (len(status) == self.nrotation and status[0] == 0
-                and all(value >= 0 for value in status))
+        return self.invalid_rotor_reason(rotor) is None
+
+    def demoted_rotor_summary(self):
+        """One-line account of the rotors MESS will treat as harmonic, or ''."""
+        demoted = []
+        for rotor, rot in enumerate(self.species.dihed):
+            why = self.invalid_rotor_reason(rotor)
+            if why is not None:
+                demoted.append(f'rotor {rotor} (atoms {rot[1] + 1}-{rot[2] + 1}): {why}')
+        if not demoted:
+            return ''
+        return (f'{len(demoted)} of {len(self.species.dihed)} rotors of '
+                f'{self.species.name} will be treated as harmonic oscillators '
+                f'in MESS: ' + '; '.join(demoted))
 
     def check_hir(self, wait=0):
         """
@@ -210,6 +236,9 @@ class HIR:
                     a = self.fourier_fit(job, angles, rotor)
                     if(a == 0):
                         logger.warning("FAILED HIR - empty energy array sent to fourier_fit for " + job)
+                summary = self.demoted_rotor_summary()
+                if summary:
+                    logger.warning('\t' + summary)
                 return 1
             else:
                 if wait:

--- a/kinbot/hindered_rotors.py
+++ b/kinbot/hindered_rotors.py
@@ -36,6 +36,8 @@ class HIR:
         self.hir_status = []
         # energies of all the HIR scan points
         self.hir_energies = []
+        # Results before failed points are filled from a Fourier fit.
+        self.hir_raw_energies = []
         # Fourier fit of each scan
         self.hir_fourier = []
         # number of terms for Fourier
@@ -50,6 +52,8 @@ class HIR:
         # re-initialize the lists in case of a restart of the HIR scans
         self.hir_status = []
         self.hir_energies = []
+        self.hir_raw_energies = []
+        self.hir_fourier = []
         self.hir_geoms = []
 
         while len(self.hir_status) < len(self.species.dihed):
@@ -192,8 +196,6 @@ class HIR:
                     a = self.fourier_fit(job, angles, rotor)
                     if(a == 0):
                         logger.warning("FAILED HIR - empty energy array sent to fourier_fit for " + job)
-                    else:
-                        self.hir_fourier.append(self.fourier_fit(job, angles, rotor))
                 return 1
             else:
                 if wait:
@@ -224,6 +226,12 @@ class HIR:
         """
         energies = self.hir_energies[rotor]
         status = self.hir_status[rotor]
+        while len(self.hir_fourier) <= rotor:
+            self.hir_fourier.append(None)
+        while len(self.hir_raw_energies) <= rotor:
+            self.hir_raw_energies.append(None)
+        if self.hir_raw_energies[rotor] is None:
+            self.hir_raw_energies[rotor] = list(energies)
 
         ang = [angles[i] for i in range(len(status)) if status[i] == 0]
         ens = [(energies[i] - energies[0])*constants.AUtoKCAL for i in range(len(status)) if status[i] == 0]
@@ -237,6 +245,7 @@ class HIR:
         if(len(ens) > 0):
             a = 1
             self.A = np.linalg.lstsq(X, np.array(ens), rcond=None)[0]
+            self.hir_fourier[rotor] = self.A.copy().tolist()
 
             for i, si in enumerate(status):
                 if si == 1:
@@ -253,16 +262,20 @@ class HIR:
                 plt.clf()
         else:
             self.A = 0
+            self.hir_fourier[rotor] = None
             a = 0
 
         return a
 
-    def get_fit_value(self, ai):
+    def get_fit_value(self, ai, rotor=None):
         """
         Get the fitted energy
         """
+        coefficients = self.A if rotor is None else self.hir_fourier[rotor]
+        if coefficients is None:
+            raise ValueError(f'No Fourier fit is available for rotor {rotor}.')
         e = 0.
         for j in range(self.n_terms):
-            e += self.A[j] * (1 - np.cos((j+1) * ai))
-            e += self.A[j+self.n_terms] * np.sin((j+1) * ai)
+            e += coefficients[j] * (1 - np.cos((j+1) * ai))
+            e += coefficients[j+self.n_terms] * np.sin((j+1) * ai)
         return e

--- a/kinbot/hindered_rotors.py
+++ b/kinbot/hindered_rotors.py
@@ -31,8 +31,8 @@ class HIR:
         # if 1 (default), remove bad rotors
         self.rotor_0_test = par['rotor_0_test']
 
-        # -1 (not finished), 0 (successful) or
-        # 1 (failed) for each HIR scan point
+        # -1 (not finished), 0 (successful), 1 (failed), or 2 (skipped)
+        # for each HIR scan point
         self.hir_status = []
         # energies of all the HIR scan points
         self.hir_energies = []
@@ -99,6 +99,10 @@ class HIR:
     def test_hir(self):
         for rotor in range(len(self.species.dihed)):
             for ai in range(self.nrotation):
+                if ai and self.hir_status[rotor][0] == -1:
+                    # A completed point cannot be screened against an unknown
+                    # reference energy. Revisit it after point zero finishes.
+                    continue
                 success = None
                 if self.hir_status[rotor][ai] == -1:
                     if self.species.wellorts:
@@ -123,7 +127,9 @@ class HIR:
                                                temp,
                                                0.15):
                             err, energy = self.qc.get_qc_energy(job)
-                            if ai == 0: 
+                            if err or not np.isfinite(energy):
+                                success = -1
+                            elif ai == 0:
                                 success = 1
                             # cut off barriers above 20 kcal/mol to prevent the Fourier fit to oscillate
                             elif (energy - self.hir_energies[rotor][0]) < 20. / constants.AUtoKCAL:
@@ -133,7 +139,6 @@ class HIR:
                         else:
                             success = -1
                 if success == 1:
-                    err, energy = self.qc.get_qc_energy(job)
                     self.hir_status[rotor][ai] = 0
                     self.hir_energies[rotor][ai] = energy
                     self.hir_geoms[rotor][ai] = geom
@@ -145,9 +150,20 @@ class HIR:
 
         return 0
 
+    def is_valid_rotor(self, rotor):
+        """Whether a completed scan has a usable reference point.
+
+        Failed non-reference points retain the existing Fourier-fill policy.
+        Completion alone does not enable a failed or skipped rotor.
+        """
+        status = self.hir_status[rotor]
+        return (len(status) == self.nrotation and status[0] == 0
+                and all(value >= 0 for value in status))
+
     def check_hir(self, wait=0):
         """
-        Check for hir calculations and optionally wait for them to finish
+        Return completion, including failed/skipped scans. Use is_valid_rotor
+        to decide which completed scans can replace harmonic modes.
         """
         while 1:
             # check if all the calculations are finished
@@ -158,7 +174,7 @@ class HIR:
                 status = self.hir_status[rotor]
                 if any([st < 0 for st in status]):  # at least one is running
                     continue
-                if self.hir_status[rotor][0] == 1:  # the starting point failed
+                if self.hir_status[rotor][0] in (1, 2):  # failed or skipped
                     continue
                 energies = self.hir_energies[rotor]
                 if abs(energies[0] - self.species.energy) * constants.AUtoKCAL > 0.1 and self.rotor_0_test:
@@ -172,10 +188,6 @@ class HIR:
                     logger.warning(rotor)
                     logger.warning(energies)
                     self.hir_status = [[1 for ai in ri] for ri in self.hir_status]
-                #    return 0
-                # energies taken if status = 0, successful geom check or normal gauss termination
-                ens = [(energies[i] - energies[0]) * constants.AUtoKCAL 
-                       for i in range(len(status)) if status[i] == 0]
 
             # if job finishes status set to 0 or 1, if all done then do the following calculation
             if all([all([test >= 0 for test in status]) for status in self.hir_status]):
@@ -186,7 +198,7 @@ class HIR:
                         job = self.species.name + '_hir_' + str(rotor)
                     else:
                         job = str(self.species.chemid) + '_hir_' + str(rotor)
-                    if len(ens) < self.nrotation - 2:
+                    if self.hir_status[rotor].count(0) < self.nrotation - 2:
                         logger.warning("More than 2 HIR calculations failed for " + job)
 
                     angles = [i * 2 * np.pi / float(self.nrotation) for i in range(self.nrotation)]
@@ -210,10 +222,14 @@ class HIR:
         """
         with open('hir/' + job + '.xyz', 'w') as ff:
             for i in range(self.nrotation):
+                geom = np.asarray(self.hir_geoms[rotor][i])
+                if geom.shape != (self.species.natom, 3):
+                    # Failed calculations may have no geometry to display.
+                    continue
                 s = str(self.species.natom) + '\n'
                 s += 'energy = ' + str(self.hir_energies[rotor][i]) + '\n'
                 for j, at in enumerate(self.species.atom):
-                    x, y, z = self.hir_geoms[rotor][i][j]
+                    x, y, z = geom[j]
                     s += '{} {:.8f} {:.8f} {:.8f}\n'.format(at, x, y, z)
                 ff.write(s)
         return

--- a/kinbot/hindered_rotors.py
+++ b/kinbot/hindered_rotors.py
@@ -156,6 +156,8 @@ class HIR:
         Failed non-reference points retain the existing Fourier-fill policy.
         Completion alone does not enable a failed or skipped rotor.
         """
+        if rotor >= len(self.hir_status):
+            return False
         status = self.hir_status[rotor]
         return (len(status) == self.nrotation and status[0] == 0
                 and all(value >= 0 for value in status))

--- a/kinbot/mess.py
+++ b/kinbot/mess.py
@@ -871,11 +871,14 @@ class MESS:
         rotors = []
         if self.par['rotor_scan']:
             for i, rot in enumerate(species.dihed):
-                if not species.hir.is_valid_rotor(i):
-                    continue
                 if norot is not None:
                     if frequencies.skip_rotor(norot, rot) == 1:
                         continue
+                if species.hir is None:
+                    # Species optimized with just_high never ran a scan.
+                    continue
+                if not species.hir.is_valid_rotor(i):
+                    continue
                 rotorpot, rotortype = self.make_rotorpot(species, i, rot, freq_factor)
                 if rotortype == 'hindered' and bless == False:
                     rotors.append(self.hinderedrotortpl.format(group=' '.join([str(pi + 1) for pi in frequencies.partition(species, rot, species.natom)[0][1:]]),

--- a/kinbot/mess.py
+++ b/kinbot/mess.py
@@ -877,7 +877,12 @@ class MESS:
                 if species.hir is None:
                     # Species optimized with just_high never ran a scan.
                     continue
-                if not species.hir.is_valid_rotor(i):
+                why = species.hir.invalid_rotor_reason(i)
+                if why is not None:
+                    # Leave a trace in the MESS input: this torsion stays a
+                    # harmonic oscillator in the frequency list above.
+                    rotors.append(f'      ! Rotor about atoms {rot[1] + 1}-{rot[2] + 1} '
+                                  f'kept as a harmonic oscillator: {why}')
                     continue
                 rotorpot, rotortype = self.make_rotorpot(species, i, rot, freq_factor)
                 if rotortype == 'hindered' and bless == False:

--- a/kinbot/mess.py
+++ b/kinbot/mess.py
@@ -845,7 +845,7 @@ class MESS:
         # solution for 6-fold symmetry, not general enough
         if species.hir.nrotation // rotorsymm == 2:  # MESS needs at least 3 potential points
             fit_angle = 15. * 2. * np.pi / 360. 
-            fit_energy = species.hir.get_fit_value(fit_angle)  # kcal/mol
+            fit_energy = species.hir.get_fit_value(fit_angle, rotor=i)  # kcal/mol
             rotorpot_num.insert(1, fit_energy)
             rotorpot_num = [freq_factor * rpn for rpn in rotorpot_num]
             rotorpot = ' '.join(['{:.2f}'.format(ei) for ei in rotorpot_num[:species.hir.nrotation // rotorsymm + 1]])

--- a/kinbot/mess.py
+++ b/kinbot/mess.py
@@ -871,6 +871,8 @@ class MESS:
         rotors = []
         if self.par['rotor_scan']:
             for i, rot in enumerate(species.dihed):
+                if not species.hir.is_valid_rotor(i):
+                    continue
                 if norot is not None:
                     if frequencies.skip_rotor(norot, rot) == 1:
                         continue

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -276,10 +276,16 @@ class Optimize:
                                 if status:  # Finished correctly
                                     if len(self.species.hir.hir_energies) > 0:
                                         # check if along the hir potential a structure was found with a lower energy
-                                        min_en = self.species.hir.hir_energies[0][0]
+                                        min_en = min((
+                                            self.species.hir.hir_energies[rotor][0]
+                                            for rotor in range(len(self.species.dihed))
+                                            if self.species.hir.is_valid_rotor(rotor)),
+                                            default=np.inf)
                                         min_rotor = -1
                                         min_ai = -1
                                         for rotor in range(len(self.species.dihed)):
+                                            if not self.species.hir.is_valid_rotor(rotor):
+                                                continue
                                             for ai in range(self.species.hir.nrotation):
                                                 # use a 0.1 kcal/mol cutoff for numerical noise
                                                 if self.species.hir.hir_status[rotor][ai] == 0:  # do not test for fails

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -285,9 +285,10 @@ class Optimize:
                                             np.inf)
                                         min_rotor = -1
                                         min_ai = -1
+                                        # Search every converged point, including those on
+                                        # rotors whose own reference failed: they passed the
+                                        # geometry check, and a low point is a real conformer.
                                         for rotor in range(len(self.species.dihed)):
-                                            if not self.species.hir.is_valid_rotor(rotor):
-                                                continue
                                             for ai in range(self.species.hir.nrotation):
                                                 # use a 0.1 kcal/mol cutoff for numerical noise
                                                 if self.species.hir.hir_status[rotor][ai] == 0:  # do not test for fails

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -276,11 +276,13 @@ class Optimize:
                                 if status:  # Finished correctly
                                     if len(self.species.hir.hir_energies) > 0:
                                         # check if along the hir potential a structure was found with a lower energy
-                                        min_en = min((
+                                        # Preserve the original first-rotor reference
+                                        # unless that scan failed or was skipped.
+                                        min_en = next((
                                             self.species.hir.hir_energies[rotor][0]
                                             for rotor in range(len(self.species.dihed))
                                             if self.species.hir.is_valid_rotor(rotor)),
-                                            default=np.inf)
+                                            np.inf)
                                         min_rotor = -1
                                         min_ai = -1
                                         for rotor in range(len(self.species.dihed)):

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -250,7 +250,13 @@ class TestHIRStatus(unittest.TestCase):
                 writer.freerotortpl = 'free rotor'
                 writer.make_rotorpot = Mock(return_value=('0', 'free'))
                 result = writer.make_rotors(species, 1.)
-                self.assertEqual(result, 'free rotor' if status == 0 else '')
+                if status == 0:
+                    self.assertEqual(result, 'free rotor')
+                else:
+                    # The demoted rotor is documented in the MESS input itself.
+                    self.assertTrue(result.lstrip().startswith('!'), result)
+                    self.assertIn('harmonic oscillator', result)
+                    self.assertIn(f'atoms {species.dihed[0][1] + 1}-{species.dihed[0][2] + 1}', result)
                 self.assertEqual(writer.make_rotorpot.call_count, int(status == 0))
 
     def test_wells_without_a_scan_are_written_without_rotors(self):
@@ -276,6 +282,26 @@ class TestHIRStatus(unittest.TestCase):
         hir.hir_status = hir.hir_status[:1]
         self.assertTrue(hir.is_valid_rotor(0))
         self.assertFalse(hir.is_valid_rotor(1))
+        self.assertEqual(hir.invalid_rotor_reason(1), 'no scan recorded')
+
+    def test_demoted_rotors_are_reported_once_per_species(self):
+        """A rotor that falls back to harmonic must be visible in the log."""
+        hir = completed_hir([[1] * 12, [0] * 12])
+        hir.hir_energies[0] = [-1.] * 12
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'), \
+                self.assertLogs('KinBot', level='WARNING') as logs:
+            self.assertEqual(hir.check_hir(), 1)
+        text = '\n'.join(logs.output)
+        self.assertIn('1 of 2 rotors of rotor_test will be treated as harmonic oscillators', text)
+        self.assertIn('rotor 0 (atoms 2-3): reference point failed', text)
+        self.assertNotIn('rotor 1 (', text)
+
+    def test_valid_scans_produce_no_demotion_warning(self):
+        hir = completed_hir()
+        self.assertEqual(hir.demoted_rotor_summary(), '')
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'), \
+                self.assertNoLogs('KinBot', level='WARNING'):
+            self.assertEqual(hir.check_hir(), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -253,6 +253,30 @@ class TestHIRStatus(unittest.TestCase):
                 self.assertEqual(result, 'free rotor' if status == 0 else '')
                 self.assertEqual(writer.make_rotorpot.call_count, int(status == 0))
 
+    def test_wells_without_a_scan_are_written_without_rotors(self):
+        """Species optimized with just_high never build an HIR instance."""
+        atoms = molecule('CH3OH')
+        species = StationaryPoint('rxn_prod', 0, 1,
+                                  atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+        species.characterize()
+        self.assertIsNone(species.hir)
+        self.assertTrue(species.dihed)
+
+        for norot in (str(species.name), None):
+            with self.subTest(norot=norot):
+                writer = MESS.__new__(MESS)
+                writer.par = {'rotor_scan': 1}
+                writer.make_rotorpot = Mock(return_value=('0', 'free'))
+                self.assertEqual(writer.make_rotors(species, 1., norot=norot), '')
+                writer.make_rotorpot.assert_not_called()
+
+    def test_rotor_without_a_recorded_scan_is_invalid(self):
+        """dihed may outrun hir_status; that is not a usable rotor."""
+        hir = completed_hir()
+        hir.hir_status = hir.hir_status[:1]
+        self.assertTrue(hir.is_valid_rotor(0))
+        self.assertFalse(hir.is_valid_rotor(1))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -189,6 +189,50 @@ class TestHIRStatus(unittest.TestCase):
         self.assertEqual(optimization.restart, 0)
         self.assertEqual(optimization.shir, 1)
 
+    def test_low_point_on_a_failed_rotor_still_triggers_a_restart(self):
+        """A failed reference does not hide a genuine minimum found on that rotor."""
+        atoms = molecule('CH3OH')
+        species = StationaryPoint('methanol', 0, 1,
+                                  atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+        species.characterize()
+        species.dihed = species.dihed * 2
+        species.energy = -100.
+        hir = HIR(species, None, {
+            'nrotation': 12, 'plot_hir_profiles': False, 'rotor_0_test': True,
+        })
+        species.hir = hir
+        # Rotor 0: reference failed, the rest converged and point 5 is 1 kcal/mol
+        # below the optimized structure. Rotor 1: a clean scan at the reference.
+        hir.hir_status = [[1] + [0] * 11, [0] * 12]
+        hir.hir_energies = [[-1.] + [-100.] * 11, [-100.] * 12]
+        hir.hir_energies[0][5] = -100. - 1. / constants.AUtoKCAL
+        hir.hir_geoms = [[np.zeros((species.natom, 3)) for _ in range(12)] for _ in range(2)]
+        optimization = Optimize.__new__(Optimize)
+        optimization.species = species
+        optimization.name = species.name
+        optimization.qc = SimpleNamespace(
+            get_qc_geom=Mock(return_value=(0, species.geom)),
+            read_qc_hess=lambda *args: np.eye(3 * species.natom),
+            hessian_is_massweighted=lambda: False,
+        )
+        optimization.par = {
+            'conformer_search': 0, 'rotation_restart': 3, 'high_level': 0,
+            'rotor_scan': 1, 'multi_conf_tst': 0, 'L3_calc': 0,
+        }
+        optimization.shir = 0
+        optimization.restart = 0
+        optimization.just_high = False
+        optimization.defer_hir = False
+        optimization.wait = 0
+        requested = []
+        optimization.log_name = lambda *args, **kwargs: requested.append(kwargs) or 'test'
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'):
+            optimization.do_optimization()
+        self.assertEqual(optimization.restart, 1)
+        self.assertEqual((optimization.shigh, optimization.shir), (-1, -1))
+        optimization.qc.get_qc_geom.assert_called_once()
+        self.assertIn({'hir': 1, 'r': 0, 's': 5}, requested)
+
     def test_skipped_rotor_does_not_disable_successful_rotors(self):
         hir = completed_hir([[2] * 12, [0] * 12])
         hir.hir_energies[0] = [-1.] * 12

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -5,11 +5,32 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 import unittest
+from unittest.mock import Mock, patch
 
 from ase.io import read
 import numpy as np
 
 from kinbot.hindered_rotors import HIR
+from kinbot import constants
+from kinbot.mess import MESS
+
+
+def completed_hir(status=None):
+    species = SimpleNamespace(
+        natom=4, atom=['C'] * 4, name='rotor_test', chemid=123,
+        wellorts=0, energy=-100., dihed=[[0, 1, 2, 3], [1, 2, 3, 0]],
+    )
+    hir = HIR(species, None, {
+        'nrotation': 12, 'plot_hir_profiles': False, 'rotor_0_test': True,
+    })
+    angles = np.arange(12) * 2 * np.pi / 12
+    hir.hir_status = status or [[0] * 12, [0] * 12]
+    hir.hir_energies = [
+        (-100. + factor * (1 - np.cos(angles)) / constants.AUtoKCAL).tolist()
+        for factor in (1., 3.)]
+    hir.hir_geoms = [[np.zeros((4, 3)) for _ in angles] for _ in range(2)]
+    species.hir = hir
+    return hir
 
 
 class TestHIRProfile(unittest.TestCase):
@@ -40,6 +61,44 @@ class TestHIRProfile(unittest.TestCase):
                 self.assertEqual(comments, [f'energy = {e}' for e in energies])
             finally:
                 os.chdir(previous)
+
+
+class TestHIRFits(unittest.TestCase):
+    def test_completed_rotors_keep_distinct_coefficients(self):
+        hir = completed_hir()
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'), \
+                patch.object(hir, 'fourier_fit', wraps=hir.fourier_fit) as fit:
+            self.assertEqual(hir.check_hir(), 1)
+        self.assertEqual(fit.call_count, 2)
+        self.assertEqual(np.shape(hir.hir_fourier), (2, 12))
+        self.assertAlmostEqual(hir.get_fit_value(np.pi, rotor=0), 2.)
+        self.assertAlmostEqual(hir.get_fit_value(np.pi, rotor=1), 6.)
+
+    def test_filling_failed_points_preserves_raw_results(self):
+        hir = completed_hir()
+        hir.n_terms = 2
+        hir.hir_status[0][3] = 1
+        hir.hir_energies[0][3] = -1.
+        angles = np.arange(12) * 2 * np.pi / 12
+        hir.fourier_fit('test', angles, 0)
+        self.assertEqual(hir.hir_raw_energies[0][3], -1.)
+        self.assertEqual(hir.hir_status[0][3], 1)
+        self.assertAlmostEqual(
+            hir.hir_energies[0][3], -100. + 1. / constants.AUtoKCAL)
+        hir.fourier_fit('test', angles, 0)
+        self.assertEqual(hir.hir_raw_energies[0][3], -1.)
+
+    def test_mess_extra_point_uses_the_requested_rotor_fit(self):
+        hir = completed_hir()
+        angles = np.arange(12) * 2 * np.pi / 12
+        for rotor in range(2):
+            hir.fourier_fit('test', angles, rotor)
+        writer = MESS.__new__(MESS)
+        writer.par = {'free_rotor_thrs': 0.}
+        writer.rotorsymm = lambda species, rotor: 6
+        potential, kind = writer.make_rotorpot(hir.species, 0, hir.species.dihed[0], 1.)
+        self.assertEqual(kind, 'hindered')
+        self.assertEqual(float(potential.split()[1]), round(1 - np.cos(np.pi / 12), 2))
 
 
 if __name__ == '__main__':

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -1,18 +1,22 @@
 """Regression tests for hindered-rotor results, without QC calculations."""
 
 import os
+from io import StringIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, mock_open, patch
 
 from ase.io import read
+from ase.build import molecule
 import numpy as np
 
 from kinbot.hindered_rotors import HIR
-from kinbot import constants
+from kinbot import constants, frequencies
 from kinbot.mess import MESS
+from kinbot.optimize import Optimize
+from kinbot.stationary_pt import StationaryPoint
 
 
 def completed_hir(status=None):
@@ -34,6 +38,20 @@ def completed_hir(status=None):
 
 
 class TestHIRProfile(unittest.TestCase):
+    def test_missing_failed_point_geometry_does_not_discard_other_frames(self):
+        hir = HIR(SimpleNamespace(natom=1, atom=['H']), None, {
+            'nrotation': 3, 'plot_hir_profiles': False, 'rotor_0_test': True,
+        })
+        hir.hir_energies = [[-100., -1., -99.99]]
+        hir.hir_geoms = [[[[0., 0., 0.]], [], [[2., 0., 0.]]]]
+        output = mock_open()
+        with patch('builtins.open', output):
+            hir.write_profile(0, 'partial')
+        contents = ''.join(call.args[0] for call in output().write.call_args_list)
+        frames = read(StringIO(contents), index=':', format='xyz')
+        self.assertEqual(len(frames), 2)
+        np.testing.assert_array_equal(frames[1].positions, [[2., 0., 0.]])
+
     def test_combined_xyz_contains_every_scan_point(self):
         with TemporaryDirectory() as directory:
             previous = Path.cwd()
@@ -99,6 +117,108 @@ class TestHIRFits(unittest.TestCase):
         potential, kind = writer.make_rotorpot(hir.species, 0, hir.species.dihed[0], 1.)
         self.assertEqual(kind, 'hindered')
         self.assertEqual(float(potential.split()[1]), round(1 - np.cos(np.pi / 12), 2))
+
+
+class TestHIRStatus(unittest.TestCase):
+    def test_failed_first_rotor_does_not_trigger_a_conformer_restart(self):
+        atoms = molecule('CH3OH')
+        species = StationaryPoint('methanol', 0, 1,
+                                  atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+        species.characterize()
+        species.dihed = species.dihed * 2
+        species.energy = -100.
+        hir = HIR(species, None, {
+            'nrotation': 12, 'plot_hir_profiles': False, 'rotor_0_test': True,
+        })
+        species.hir = hir
+        hir.hir_status = [[1] * 12, [0] * 12]
+        hir.hir_energies = [[-1.] * 12, [-100.] * 12]
+        optimization = Optimize.__new__(Optimize)
+        optimization.species = species
+        optimization.name = species.name
+        optimization.qc = SimpleNamespace(
+            get_qc_geom=Mock(side_effect=AssertionError('Unexpected conformer restart')),
+            read_qc_hess=lambda *args: np.eye(3 * species.natom),
+            hessian_is_massweighted=lambda: False,
+        )
+        optimization.par = {
+            'conformer_search': 0, 'rotation_restart': 3, 'high_level': 0,
+            'rotor_scan': 1, 'multi_conf_tst': 0, 'L3_calc': 0,
+        }
+        optimization.shir = 0
+        optimization.restart = 0
+        optimization.just_high = False
+        optimization.defer_hir = False
+        optimization.wait = 0
+        optimization.log_name = lambda *args, **kwargs: 'test'
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'):
+            optimization.do_optimization()
+        self.assertEqual(optimization.restart, 0)
+        self.assertEqual(optimization.shir, 1)
+
+    def test_skipped_rotor_does_not_disable_successful_rotors(self):
+        hir = completed_hir([[2] * 12, [0] * 12])
+        hir.hir_energies[0] = [-1.] * 12
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'):
+            self.assertEqual(hir.check_hir(), 1)
+        self.assertEqual(hir.hir_status, [[2] * 12, [0] * 12])
+        self.assertFalse(hir.is_valid_rotor(0))
+        self.assertTrue(hir.is_valid_rotor(1))
+
+    def test_failure_count_warning_uses_each_rotors_status(self):
+        hir = completed_hir()
+        hir.hir_status[0][1:4] = [1, 1, 1]
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'), \
+                self.assertLogs('KinBot', level='WARNING') as logs:
+            hir.check_hir()
+        self.assertIn('More than 2 HIR calculations failed for 123_hir_0', '\n'.join(logs.output))
+
+    def test_barrier_check_waits_for_reference_energy(self):
+        atoms = molecule('CH3OH')
+        species = StationaryPoint('methanol', 0, 1,
+                                  atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+        species.characterize()
+        qc = Mock()
+        qc.get_qc_geom.side_effect = lambda job, natom: (
+            1 if job.endswith('_00') else 0, species.geom)
+        qc.get_qc_energy.side_effect = lambda job: (
+            0, -100. if job.endswith('_00') else -99.95)
+        hir = HIR(species, qc, {
+            'nrotation': 12, 'plot_hir_profiles': False, 'rotor_0_test': True,
+        })
+        hir.hir_status = [[-1] * 12]
+        hir.hir_energies = [[-1.] * 12]
+        hir.hir_geoms = [[[] for _ in range(12)]]
+        hir.test_hir()
+        self.assertEqual(hir.hir_status, [[-1] * 12])
+        qc.get_qc_geom.side_effect = lambda job, natom: (0, species.geom)
+        hir.test_hir()
+        self.assertEqual(hir.hir_status[0], [0] + [1] * 11)
+
+    def test_failed_or_skipped_rotors_keep_their_harmonic_modes(self):
+        atoms = molecule('CH3OH')
+        for status in (-1, 0, 1, 2):
+            with self.subTest(status=status):
+                species = StationaryPoint('methanol', 0, 1,
+                                          atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+                species.characterize()
+                species.hir = HIR(species, None, {
+                    'nrotation': 12, 'plot_hir_profiles': False, 'rotor_0_test': True,
+                })
+                species.hir.hir_status = [[status] * 12]
+                raw, projected = frequencies.get_frequencies(
+                    species, np.eye(3 * species.natom), species.geom)
+                self.assertEqual(len(projected), len(raw) - (status == 0))
+                if status != 0:
+                    np.testing.assert_allclose(projected, raw, rtol=1.e-8)
+
+                writer = MESS.__new__(MESS)
+                writer.par = {'rotor_scan': 1}
+                writer.freerotortpl = 'free rotor'
+                writer.make_rotorpot = Mock(return_value=('0', 'free'))
+                result = writer.make_rotors(species, 1.)
+                self.assertEqual(result, 'free rotor' if status == 0 else '')
+                self.assertEqual(writer.make_rotorpot.call_count, int(status == 0))
 
 
 if __name__ == '__main__':

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -120,6 +120,39 @@ class TestHIRFits(unittest.TestCase):
 
 
 class TestHIRStatus(unittest.TestCase):
+    def test_successful_rotors_keep_the_original_restart_reference(self):
+        hir = completed_hir()
+        # Both reference points pass the 0.1 kcal/mol check. The second
+        # scan finds a point below the restart threshold relative to rotor
+        # zero, even though its own reference is slightly lower already.
+        hir.hir_energies = [[-100.] * 12, [-100.00015] * 12]
+        hir.hir_energies[1][1] = -100.0003
+        optimization = Optimize.__new__(Optimize)
+        optimization.species = hir.species
+        optimization.name = hir.species.name
+        optimization.qc = SimpleNamespace(
+            read_qc_hess=lambda *args: np.eye(12),
+            hessian_is_massweighted=lambda: False,
+            qc='gauss',
+        )
+        optimization.par = {
+            'conformer_search': 0, 'rotation_restart': 1, 'high_level': 0,
+            'rotor_scan': 1, 'multi_conf_tst': 0, 'L3_calc': 0,
+        }
+        optimization.shir = 0
+        optimization.restart = 0
+        optimization.just_high = False
+        optimization.defer_hir = False
+        optimization.wait = 0
+        optimization.log_name = lambda *args, **kwargs: 'test'
+        hir.species.geom = np.zeros((4, 3))
+        with patch.object(hir, 'test_hir'), patch.object(hir, 'write_profile'), \
+                patch('kinbot.optimize.symmetry.calculate_symmetry'), \
+                patch('kinbot.optimize.frequencies.get_frequencies', return_value=([], [])):
+            optimization.do_optimization()
+        self.assertEqual(optimization.restart, 1)
+        self.assertEqual(optimization.shir, 1)
+
     def test_failed_first_rotor_does_not_trigger_a_conformer_restart(self):
         atoms = molecule('CH3OH')
         species = StationaryPoint('methanol', 0, 1,


### PR DESCRIPTION
Targeting master now...

HIR correctness fixes split out of #92 (part B of 4). **Base branch is `kb-fixes-mechanical`** (PR A), so this diff shows only the six HIR commits. Luka's three commits are cherry-picked verbatim with original authorship; three follow-up commits address issues found in review.

Unlike A, this PR **changes what MESS receives** for species with a partially failed rotor scan. Previously such rotors were written with potentials built from the `-1` Hartree failure sentinel, which made every relative energy non-positive and so came out as **free rotors**. They now stay harmonic oscillators, and both the KinBot log and the MESS input say so.

| Commit | Author | Fix |
|---|---|---|
| Store Fourier coefficients and raw energies separately for each rotor | Luka | `hir_fourier` was appended only for successful fits (and `fourier_fit` was called twice), so MESS's 6-fold-symmetry extra point read `self.A` from whichever rotor was fitted last. Coefficients are now per rotor; `get_fit_value(..., rotor=i)`. |
| Keep failed and skipped HIR scans out of thermochemical rotor treatment | Luka | Adds `is_valid_rotor`, applied consistently to the MESS rotor list, the Hessian projection that produces `reduced_freqs`, and the restart scan. A rotor whose reference point failed is dropped from MESS and its harmonic mode retained. Also fixes the status-2 (skipped) fall-through into the rotor-0 energy check, and stops screening points against an unknown reference while point 0 is still running. |
| Preserve the original HIR restart reference for successful scans | Luka | `min_en = hir_energies[0][0]` was `-1` Ha when rotor 0's reference failed, so every real point looked "lower" and triggered the conformer restart up to `rotation_restart` times, each deleting and redoing the high-level and HIR jobs. Reference now comes from the first valid rotor. |
| Guard rotor validity checks against species without a scan | review | `make_rotors` consulted `species.hir` before the `norot` filter, but `just_high` species (vdW wells) never build an HIR instance → `AttributeError` in MESS for any PES with a vdW well and `rotor_scan = 1`. Reordered; `is_valid_rotor` also bounds-checks. |
| Report rotors that fall back to harmonic oscillators | review | The substitution above was silent. Adds `invalid_rotor_reason()`, writes a `!` comment into the MESS input where the rotor block would have been, and logs one summary warning per species when scans complete. |
| Search every converged HIR point for a lower conformer | review | The restart *reference* must come from a valid rotor, but the *search* should still visit converged points on rotors whose reference failed: they passed the geometry check, and the only screen they bypassed admits high points, not low ones. |

**Policy encoded here, for reviewers:** a rotor with a failed non-reference point keeps the existing Fourier-fill behaviour; a rotor whose reference point (0°) failed, was skipped, or was disabled by the rotor-0 energy test reverts to a harmonic oscillator. The MESS input records which rotors were demoted and why.

Tests: `python -m unittest tests.test_hindered_rotors` → 16 pass. Full new-test set → 28 pass, 2 skipped (RDKit optional). Full `tests/` discovery matches the `master` baseline (17 errors / 1 failure, pre-existing pybel/RDKit import errors).

Follow-ups: **C** (conformers: ZPE double count in Boltzmann screening, L0 search plumbing) is rebased on this branch and ready once B is in. **D** (`semi_emp_*` → `L0_*` rename) is held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
