### PR TITLE
Conformer fixes from #92 (C/4)

### DIFF
--- a/kinbot/conformers.py
+++ b/kinbot/conformers.py
@@ -641,6 +641,7 @@ class Conformers:
         test all previous structures.
 
         temp is temperature, and only exp(-G/RT) > boltz conformers are considered if defined.
+        energies contains E + ZPE in Hartree, as returned by check_conformers.
         returns the geometries, total energies, frequencies, and indices (as in the /conf directory)
         """
 
@@ -653,9 +654,11 @@ class Conformers:
         if temp is not None:
             # calculate the Gibbs free energy for all conformers
             # at T = temp, P = 101325 Pa
-            gibbs = []
+            gibbs = [np.inf for _ in valid]
             geo_type = 'nonlinear'
             for vi, val in enumerate(valid):
+                if val != 0:
+                    continue
                 if frequencies == [None]:
                     vib_energies = [0]
                     geo_type = 'monatomic'
@@ -663,14 +666,18 @@ class Conformers:
                     vib_energies = [ff * invcm for ff in frequencies[vi] if ff > 0]  # convert to eV
                     if np.shape(frequencies)[1] == 3 * len(self.species.atom) - 5:
                         geo_type = 'linear'
-                potentialenergy = energies[vi] * Hartree  # convert to eV
+                potentialenergy = energies[vi] * Hartree  # E + ZPE, in eV
                 atoms = Atoms(symbols=self.species.atom, positions=conformers[vi])
                 thermo = IdealGasThermo(vib_energies=vib_energies,
                                         potentialenergy=potentialenergy,
                                         atoms=atoms,
                                         geometry=geo_type,
                                         symmetrynumber=1, spin=(self.species.mult-1)/2)
-                gibbs.append(thermo.get_gibbs_energy(temperature=temp, pressure=101325., verbose=False))
+                # The input already contains the calculation's ZPE. Add only
+                # thermal corrections, removing ASE's additional harmonic ZPE.
+                gibbs[vi] = (thermo.get_gibbs_energy(
+                    temperature=temp, pressure=101325., verbose=False)
+                    - thermo.get_ZPE_correction())
 
         for vi, val in enumerate(valid):
             unique = True

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -62,11 +62,13 @@ class Optimize:
             #  1: finished
             # -999:failed
             self.scycconf = -1
+            self.ssemi_empconf = -1
             self.sconf = -1
             self.shir = -1
         else:
             # Do not perform conformer search for vdW wells
             self.scycconf = 1
+            self.ssemi_empconf = 1
             self.sconf = 1
             self.shir = 1
 
@@ -106,9 +108,9 @@ class Optimize:
                         self.scycconf = 1
                 # first do an semi empirical optimization if requested by the user
                 if self.par['semi_emp_conformer_search'] == 1:
-                    logger.info('\tSemi-empirical conformer search is starting '
-                                f'for {self.name}')
-                    if self.ssemi_empconf == -1:
+                    if self.ssemi_empconf == -1 and self.scycconf == 1:
+                        logger.info('\tSemi-empirical conformer search is starting '
+                                    f'for {self.name}')
                         # semi empirical part has not started yet
                         self.species.semi_emp_confs = Conformers(self.species, self.par, self.qc, semi_emp=1)
                         for geom in self.species.confs.cyc_conf_geoms:
@@ -117,16 +119,17 @@ class Optimize:
                             self.species.semi_emp_confs.generate_conformers(0, geom)
                         # set conf status to running
                         self.ssemi_empconf = 0
-                        if self.ssemi_empconf == 0:
-                            # semi empirical conformational search is running
-                            # check if the conformational search is done
-                            status, lowest_conf, geom, self.semi_emp_low_energy, self.semi_emp_conformers, self.semi_emp_energies = self.species.semi_emp_confs.check_conformers(wait=self.wait)
-                            if status == 1:
-                                logger.info("\tSemi- empirical lowest energy "
-                                            f"conformer for species {self.name}"
-                                            f" is number {lowest_conf}")
-                                # set conf status to finished
-                                self.ssemi_empconf = 1
+                    if self.ssemi_empconf == 0:
+                        # Poll on subsequent calls as well as immediately after submission.
+                        (status, lowest_conf, geom, self.semi_emp_low_energy,
+                         self.semi_emp_conformers, self.semi_emp_energies,
+                         _, self.semi_emp_valid) = \
+                            self.species.semi_emp_confs.check_conformers(wait=self.wait)
+                        if status == 1:
+                            logger.info("\tSemi-empirical lowest energy "
+                                        f"conformer for species {self.name}"
+                                        f" is number {lowest_conf}")
+                            self.ssemi_empconf = 1
                 else:
                     self.ssemi_empconf = 1
                 if self.ssemi_empconf == 1 and self.scycconf == 1:
@@ -137,11 +140,23 @@ class Optimize:
                         # else start from cyclic conformers
                         if self.par['semi_emp_conformer_search'] == 1:
                             self.species.confs.nconfs = 1
-                            for i, geom in enumerate(self.semi_emp_conformers):
-                                if (self.semi_emp_energies[i] - self.semi_emp_low_energy) * constants.AUtoKCAL < self.par['semi_emp_confomer_threshold']:
-                                    self.species.confs.generate_conformers(-999, geom)
+                            valid = [(geom, energy) for geom, energy, status in zip(
+                                self.semi_emp_conformers, self.semi_emp_energies,
+                                self.semi_emp_valid) if status == 0]
+                            if valid:
+                                # check_conformers supplies E + ZPE for this list.
+                                minimum = min(energy for _, energy in valid)
+                                seeds = [geom for geom, energy in valid
+                                         if (energy - minimum) * constants.AUtoKCAL
+                                         < self.par['semi_emp_confomer_threshold']]
+                            else:
+                                logger.warning('No valid semi-empirical conformers for %s; '
+                                               'using the input ring conformers at L1.', self.name)
+                                seeds = self.species.confs.cyc_conf_geoms
+                            for geom in seeds:
+                                self.species.confs.generate_conformers(-999, geom)
                             logger.info("\tThere are {} structures below the {} kcal/mol threshold for species {} in the semiempirical search.". \
-                                         format(i, self.par['semi_emp_confomer_threshold'], self.name))
+                                         format(len(seeds), self.par['semi_emp_confomer_threshold'], self.name))
                         else:
                             print_warning = True
                             for geom in self.species.confs.cyc_conf_geoms:

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -139,7 +139,6 @@ class Optimize:
                         # if semi empirical conformer were searched for, start from those,
                         # else start from cyclic conformers
                         if self.par['semi_emp_conformer_search'] == 1:
-                            self.species.confs.nconfs = 1
                             valid = [(geom, energy) for geom, energy, status in zip(
                                 self.semi_emp_conformers, self.semi_emp_energies,
                                 self.semi_emp_valid) if status == 0]
@@ -149,14 +148,24 @@ class Optimize:
                                 seeds = [geom for geom, energy in valid
                                          if (energy - minimum) * constants.AUtoKCAL
                                          < self.par['semi_emp_confomer_threshold']]
+                                # The dihedrals were already sampled semi-empirically,
+                                # so each surviving geometry is optimized as given.
+                                self.species.confs.nconfs = 1
+                                for geom in seeds:
+                                    self.species.confs.generate_conformers(-999, geom)
+                                logger.info("\tThere are {} structures below the {} kcal/mol threshold for species {} in the semiempirical search.". \
+                                             format(len(seeds), self.par['semi_emp_confomer_threshold'], self.name))
                             else:
+                                # Seeding L1 with the ring conformers alone would
+                                # skip the dihedral search entirely. Run the
+                                # regular search instead.
                                 logger.warning('No valid semi-empirical conformers for %s; '
-                                               'using the input ring conformers at L1.', self.name)
-                                seeds = self.species.confs.cyc_conf_geoms
-                            for geom in seeds:
-                                self.species.confs.generate_conformers(-999, geom)
-                            logger.info("\tThere are {} structures below the {} kcal/mol threshold for species {} in the semiempirical search.". \
-                                         format(len(seeds), self.par['semi_emp_confomer_threshold'], self.name))
+                                               'falling back to the standard conformer search.', self.name)
+                                print_warning = True
+                                for geom in self.species.confs.cyc_conf_geoms:
+                                    self.skip_conf_check = self.species.confs.generate_conformers(
+                                        0, geom, print_warning=print_warning)
+                                    print_warning = False
                         else:
                             print_warning = True
                             for geom in self.species.confs.cyc_conf_geoms:

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -4,6 +4,7 @@ import json
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import SimpleNamespace
 import unittest
 from unittest.mock import Mock, patch
 
@@ -11,8 +12,33 @@ from ase.build import molecule
 import numpy as np
 
 from kinbot.optimize import Optimize
+from kinbot.conformers import Conformers
 from kinbot.parameters import Parameters
 from kinbot.stationary_pt import StationaryPoint
+
+
+class TestConformerWeights(unittest.TestCase):
+    def setUp(self):
+        self.conformers = Conformers.__new__(Conformers)
+        atoms = molecule('H2O')
+        self.conformers.species = SimpleNamespace(atom=atoms.get_chemical_symbols(), mult=1)
+        self.geometries = [atoms.positions.copy(), atoms.positions * 1.2]
+
+    def test_equal_total_energies_do_not_acquire_a_second_zpe_bias(self):
+        # Both supplied E + ZPE values are equal. Different high-frequency
+        # modes must not add their ground-state energies a second time.
+        result = self.conformers.find_unique(
+            self.geometries, [0., 0.],
+            [[1000., 1500., 3000.], [2000., 2500., 4000.]], [0, 0],
+            temp=298.15, boltz=.1)
+        self.assertEqual(result[-1], [0, 1])
+        self.assertEqual(result[1], [0., 0.])
+
+    def test_invalid_conformer_cannot_set_the_boltzmann_reference(self):
+        result = self.conformers.find_unique(
+            self.geometries, [0., -100.], [[1000., 1500., 3000.]] * 2,
+            [0, 1], temp=298.15, boltz=.1)
+        self.assertEqual(result[-1], [0])
 
 
 class TestSemiEmpiricalConformers(unittest.TestCase):

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -97,14 +97,20 @@ class TestSemiEmpiricalConformers(unittest.TestCase):
         self.optimization.do_optimization()
         self.assertEqual(self.regular.generate_conformers.call_count, 1)
         np.testing.assert_array_equal(self.regular.generate_conformers.call_args.args[1], self.geom)
+        # Surviving geometries are optimized as given, without a new scan.
+        self.assertEqual(self.regular.generate_conformers.call_args.args[0], -999)
 
-    def test_all_failed_search_falls_back_to_input_conformers(self):
+    def test_all_failed_search_falls_back_to_the_standard_search(self):
         self.semi.check_conformers.side_effect = None
         self.semi.check_conformers.return_value = (
             1, '0000', self.geom, -10., [], [], [], [1])
         self.optimization.do_optimization()
         self.assertEqual(self.regular.generate_conformers.call_count, 1)
         np.testing.assert_array_equal(self.regular.generate_conformers.call_args.args[1], self.geom)
+        # Without valid seeds the dihedrals still have to be searched, so the
+        # rotor index must start the recursion rather than skip it.
+        self.assertEqual(self.regular.generate_conformers.call_args.args[0], 0)
+        self.assertNotEqual(self.optimization.species.confs.nconfs, 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -1,0 +1,85 @@
+"""Conformer workflow regressions without electronic-structure jobs."""
+
+import json
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import Mock, patch
+
+from ase.build import molecule
+import numpy as np
+
+from kinbot.optimize import Optimize
+from kinbot.parameters import Parameters
+from kinbot.stationary_pt import StationaryPoint
+
+
+class TestSemiEmpiricalConformers(unittest.TestCase):
+    def setUp(self):
+        temporary = TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.addCleanup(os.chdir, Path.cwd())
+        os.chdir(temporary.name)
+        Path('input.json').write_text(json.dumps({
+            'barrier_threshold': 50., 'conformer_search': 1,
+            'semi_emp_conformer_search': 1, 'semi_emp_confomer_threshold': 5.,
+        }))
+        self.par = Parameters('input.json', show_warnings=False).par
+        atoms = molecule('CH4')
+        self.species = StationaryPoint(
+            'methane', 0, 1, atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+        self.species.characterize()
+        self.optimization = Optimize(self.species, self.par, None)
+        self.geom = self.species.geom.copy()
+        self.regular = Mock(cyc_conf_geoms=[])
+        self.regular.check_conformers.return_value = (0, '0000', self.geom, -10., [], [], [], [])
+        self.semi = Mock()
+        self.semi.check_conformers.side_effect = [
+            (0, '0000', self.geom, -10., [], [], [], []),
+            (1, '0000', self.geom, -10., [self.geom], [-9.95], [[100.]], [0]),
+        ]
+        factory = patch('kinbot.optimize.Conformers', side_effect=lambda *a, **kw:
+                        self.semi if kw.get('semi_emp') else self.regular)
+        factory.start()
+        self.addCleanup(factory.stop)
+
+    def test_running_search_is_polled_again_without_resubmission(self):
+        self.optimization.do_optimization()
+        self.assertEqual(self.optimization.ssemi_empconf, 0)
+        self.regular.generate_conformers.assert_not_called()
+        self.optimization.do_optimization()
+        self.assertEqual(self.optimization.ssemi_empconf, 1)
+        self.assertEqual(self.semi.generate_conformers.call_count, 1)
+        self.assertEqual(self.semi.check_conformers.call_count, 2)
+        self.assertEqual(self.regular.generate_conformers.call_count, 1)
+
+    def test_waits_for_ring_conformers_before_starting_semi_empirical_jobs(self):
+        self.species.cycle_chain = [[0, 1, 2, 3]]
+        self.regular.check_ring_conformers.side_effect = [(0, []), (1, [self.geom])]
+        self.optimization.do_optimization()
+        self.semi.generate_conformers.assert_not_called()
+        self.optimization.do_optimization()
+        self.assertEqual(self.semi.generate_conformers.call_count, 1)
+
+    def test_screening_compares_valid_total_energies(self):
+        self.semi.check_conformers.side_effect = None
+        self.semi.check_conformers.return_value = (
+            1, '0000', self.geom, -10.,
+            [self.geom, self.geom + .1, self.geom + .2],
+            [-9.95, -9.94, -20.], [[100.]] * 3, [0, 0, 1])
+        self.optimization.do_optimization()
+        self.assertEqual(self.regular.generate_conformers.call_count, 1)
+        np.testing.assert_array_equal(self.regular.generate_conformers.call_args.args[1], self.geom)
+
+    def test_all_failed_search_falls_back_to_input_conformers(self):
+        self.semi.check_conformers.side_effect = None
+        self.semi.check_conformers.return_value = (
+            1, '0000', self.geom, -10., [], [], [], [1])
+        self.optimization.do_optimization()
+        self.assertEqual(self.regular.generate_conformers.call_count, 1)
+        np.testing.assert_array_equal(self.regular.generate_conformers.call_args.args[1], self.geom)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Conformer fixes split out of #92 (part C of 4), on top of A (#93) and B (#95). Luka's two commits are cherry-picked verbatim with original authorship; one follow-up commit addresses an issue found in review.

**This PR changes results for multi-conformer TST runs** (commit 1). It also enables the semi-empirical pre-search, which has never executed before (commits 2–3); nothing changes for runs that leave `semi_emp_conformer_search` at its default of 0.

| Commit | Author | Fix |
|---|---|---|
| Count zero-point energy once when screening conformer populations | Luka | `find_unique` passed E + ZPE (from `check_conformers`, which stores `energy + zpe`) to `IdealGasThermo` as `potentialenergy`, and ASE adds its own harmonic ZPE on top, so every conformer carried ZPE twice. Relative Gibbs energies were off by the inter-conformer ZPE *difference*, tenths of a kcal/mol — the same scale as the Boltzmann threshold. Second defect: conformers failing the frequency check are flagged invalid *after* their real energy is stored, so an invalid low-lying structure could set `min(gibbs)` and suppress every valid conformer. Fix subtracts `get_ZPE_correction()` and skips invalid entries. Only active when `multi_conf_tst = 1` (`multi_conf_tst_temp` is forced to `None` otherwise). Verified per backend: Gaussian, Q-Chem, Sella and FairChem templates all store a real ZPE. |
| Advance semi-empirical conformer searches through their asynchronous stages | Luka | The `semi_emp_conformer_search` path was dead code: `self.ssemi_empconf` was never initialised (`AttributeError`), the poll sat inside the "not started" block so it ran once, and it unpacked 6 values from `check_conformers`' 8-tuple. Now initialised, polled every pass, gated on the ring search finishing, and screens survivors with validity flags. |
| Search dihedrals when no semi-empirical conformer survives | review | The fallback when every semi-empirical conformer failed seeded L1 through the `-999` single-point path, i.e. **no** dihedral search — quietly weaker than not using the pre-search at all. Now runs the standard conformer search; `nconfs = 1` is clamped only when the dihedrals were actually sampled at L0. |

**Known follow-up for @LukaDockx, deliberately not fixed here:** the semi-empirical stage is not gated on `wellorts`, so a saddle point with `semi_emp_conformer_search = 1` would get an AM1 TS optimisation. Intent is wells only; semi-empirical methods are unreliable at saddle geometries. A `not self.species.wellorts` condition on the L0 block in `optimize.py` is the fix.

Also noted, not addressed: the NWChem conformer template writes neither `zpe` nor `frequencies`, so NWChem conformers are already flagged invalid before any of this code runs.

Tests: `python -m unittest tests.test_conformers` → 6 pass. Full new-test set → 34 pass, 2 skipped (RDKit optional). Full `tests/` discovery matches the `master` baseline (17 errors / 1 failure, pre-existing pybel/RDKit import errors).

Remaining from #92: **D** (`semi_emp_*` → `L0_*` input rename) is held; see the split discussion on #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
