### PR TITLE
release 2.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 ## Description
-This repository contains the KinBot code version 2.2.1,
+This repository contains the KinBot code version 2.4.0,
 a tool for automatically searching for reactions on the potential energy surface.
 
 If you are using this tool in scientific publications, please reference the following publications:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "kinbot" %}
-{% set version = "2.3.0" %}
+{% set version = "2.4.0" %}
 {% set python_min = "3.11" %}
 
 package:
@@ -29,7 +29,7 @@ requirements:
         - ase >=3.26
         - networkx
         - rmsd >=1.5.1
-        - sella >=2.5.0
+        - sella >=2.6.0
 
 test:
   imports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ exclude = ["build", "dist", "KinBot.egg-info", "graphics"]
 
 [project]
 name = "kinbot"
-version = "2.3.0"
+version = "2.4.0"
 description = "Automated reaction kinetics for gas-phase species"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
# KinBot 2.4.0

Bugfix-heavy minor release. Several fixes change numerical output for inputs that ran before; those are listed first so you know what to expect when comparing against 2.3.0 results.

## Read this first

**Dependency floors raised**
- `sella >= 2.6.0` (was 2.5.0). The Sella IRC compatibility shim was removed (#91).
- `fairchem-core >= 2.14` (was 2.0), in the `fc` extra. New `bimol` extra pulls in `fc`.

**Results change for unchanged inputs**
- **Hindered rotors** (#95): a rotor whose reference-point scan failed is now kept as a harmonic oscillator. Previously it reached MESS as a *free* rotor, because the failure sentinel made every relative energy non-positive. The demotion is reported once per species in the log and as a `!` comment in the MESS input where the rotor block would have been.
- **Multi-conformer TST** (#96): the Boltzmann screen in `find_unique` no longer counts ZPE twice (once from the QC job, once from ASE's `IdealGasThermo`). Relative Gibbs energies shift by the inter-conformer ZPE difference. Conformers that failed the frequency check no longer set the Boltzmann reference.
- **UQ frequency scaling** is now symmetric: `v' = v · f^(freq_uq_ref / v)`, capped at `freq_uq_max_exp`, so a factor and its inverse cancel exactly. Two new keywords, `freq_uq_ref` (default 100 cm⁻¹) and `freq_uq_max_exp` (default 4).
- **Semi-empirical conformer pre-search** (`semi_emp_conformer_search = 1`) now actually runs (#96). It was dead code in every prior release; anyone with it enabled was silently getting the standard search. Note: it is not yet restricted to wells; a follow-up will gate it so saddle points skip the semi-empirical stage.
- **6-fold symmetric rotors** (#95): the extra 15° potential point MESS needs was evaluated with the Fourier coefficients of whichever rotor was fitted last. Each rotor now uses its own fit.

## New

- `allow_l2_without_conf`: run the L2 (high-level) stage without a conformer search.
- Basic Si support; element handling generalised via ASE's periodic table.
- `bimol` optional-dependency extra.

## Fixed

**Crashes and code that could not run** (#93)
- PBS job submission raised `NameError` (`proc` undefined in `submit_qc`).
- VRC-TST fragment and scan job writers referenced an undefined `species`.
- `get_molecular_formula` and the RDKit branch of `generate_3d_structure` always exited: RDKit was never imported at module scope.
- `calc_vibrations` left the process in the `*_vib/` directory after any failure.
- qchem + Sella Hessians were treated as mass-weighted; they are not.

**Hindered rotors** (#95)
- Failed reference point no longer triggers up to `rotation_restart` spurious "lower conformer found" restarts, each of which deleted and redid the high-level and HIR jobs.
- The restart search now visits every converged scan point, including those on rotors whose own reference failed.
- Skipped rotors no longer fall into the rotor-0 energy check and disable HIR for the whole species.
- MESS no longer crashes with `AttributeError` on vdW wells when `rotor_scan = 1`.
- `hir/*.xyz` scan profiles contain every scan point instead of only the last.

**Conformers** (#96)
- When every semi-empirical conformer fails, L1 falls back to the standard dihedral search instead of a single-point optimisation of the ring conformers.

**Bimolecular** (#90)
- Bookkeeping fixes for bimolecular reactions; FairChem compatibility.

**Cosmetic / diagnostics**
- Reaction depiction PNGs are no longer blank.
- L1-level and B3LYP warnings are suppressed for the FairChem backend, where method/basis do not apply.
- FairChem well optimisations log their frequencies when the frequency check fails.

## Known issues

- The NWChem conformer template writes neither `zpe` nor `frequencies`, so NWChem conformers are flagged invalid before screening. Unchanged from previous releases.
- The `semi_emp_*` → `L0_*` input rename proposed in #92 is not included; the old names remain the only names.

## Contributors

Luka Dockx, Judit Zádor.
