### PR TITLE
update conda recipe sha256 for 2.4.0 PyPI tarball

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
     url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/kinbot-{{ version }}.tar.gz
-    sha256: 23d0db17d24295bb1e4f5b7444f2c5f5dd797f966dc5d578e82aa2b4441075ba
+    sha256: d9f7b7a88ad1ea1d068ad6e89f26238db1731d8243e695f049b9e11a2d098a06
 
 build:
     noarch: python


### PR DESCRIPTION
sha256 of dist/kinbot-2.4.0.tar.gz built from 902b58d (tag 2.4.0) with python -m build. Valid only if that exact file is the one uploaded to PyPI; a rebuilt sdist has a different hash.