### PR TITLE
Fix conformer validation, fallback energies, rotor detection and MESS potential export

### DIFF
--- a/kinbot/conformers.py
+++ b/kinbot/conformers.py
@@ -462,7 +462,7 @@ class Conformers:
 
                     self.selected_job = lowest_job
                     self.selected_conf = lowest_conf
-                    return 1, lowest_conf, lowest_e_geom, last_row.data.get('energy'),\
+                    return 1, lowest_conf, lowest_e_geom, last_row.data.get('energy') * constants.EVtoHARTREE,\
                            final_geoms, totenergies, frequencies, status
 
                 for ci in range(self.conf):
@@ -568,7 +568,9 @@ class Conformers:
                     lowest_job = l1_last_row.name
                     lowest_conf = 'low'
                     lowest_e_geom = l1_last_row.positions
-                    lowest_energy = l1energy
+                    # This return field is electronic energy in Hartree;
+                    # only totenergies and the comparison above include ZPE.
+                    lowest_energy = l1_last_row.data.get('energy') * constants.EVtoHARTREE
                 
                 low_row = None
                 low_rows = self.db.select(name='conf/{}_low'.format(name))

--- a/kinbot/conformers.py
+++ b/kinbot/conformers.py
@@ -481,6 +481,21 @@ class Conformers:
                             frequencies.append(freq)
                         else:
                             frequencies.append(None)
+                        if not self.semi_emp and self.species.natom > 1:
+                            values = np.asarray(freq)
+                            invalid = (err != 0 or not len(values)
+                                       or not np.all(np.isfinite(values)))
+                            if self.species.wellorts:
+                                invalid |= (np.count_nonzero(values < 0) == 0
+                                            or np.count_nonzero(values < 0) >= 3
+                                            or np.count_nonzero(values < -self.imagfreq_threshold) >= 2)
+                            else:
+                                invalid |= np.any(values <= -self.imagfreq_threshold)
+                            if invalid:
+                                # Every member can enter a population sum,
+                                # even if it cannot replace the minimum.
+                                status[ci] = 1
+                                continue
                         if lowest_energy is np.inf:
                             if self.species.natom > 1:
                                 # job fails if conformer freq array is empty

--- a/kinbot/mess.py
+++ b/kinbot/mess.py
@@ -988,9 +988,12 @@ class MESS:
                     if frequencies.skip_rotor(norot, rot) == 1:
                         continue
                 if species.hir is None:
-                    # Species optimized with just_high never ran a scan.
-                    continue
-                why = species.hir.invalid_rotor_reason(i)
+                    if (getattr(species, 'rotor_projection', None) or {}).get('method') != 'harmonic_fallback':
+                        # Species optimized with just_high never ran a scan.
+                        continue
+                    why = 'no usable selected-geometry Hessian; hindered rotors omitted'
+                else:
+                    why = species.hir.invalid_rotor_reason(i)
                 if why is not None:
                     # Leave a trace in the MESS input: this torsion stays a
                     # harmonic oscillator in the frequency list above.

--- a/kinbot/mess.py
+++ b/kinbot/mess.py
@@ -959,17 +959,16 @@ class MESS:
         ens = species.hir.hir_energies[i]
         rotorpot_num = [(ei - ens[0]) * constants.AUtoKCAL for ei in ens]
         maxen = max(rotorpot_num)
-        # solution for 6-fold symmetry, not general enough
-        if species.hir.nrotation // rotorsymm == 2:  # MESS needs at least 3 potential points
-            fit_angle = 15. * 2. * np.pi / 360. 
-            fit_energy = species.hir.get_fit_value(fit_angle, rotor=i)  # kcal/mol
-            rotorpot_num.insert(1, fit_energy)
-            rotorpot_num = [freq_factor * rpn for rpn in rotorpot_num]
-            rotorpot = ' '.join(['{:.2f}'.format(ei) for ei in rotorpot_num[:species.hir.nrotation // rotorsymm + 1]])
+        count = self.nrotorpot(species, rot)
+        if species.hir.nrotation % rotorsymm or species.hir.nrotation // rotorsymm < 3:
+            # MESS interprets these as equally spaced points in one symmetry
+            # period, excluding its repeated endpoint. Interpolate on that grid.
+            rotorpot_num = [species.hir.get_fit_value(
+                2 * np.pi * point / (rotorsymm * count), rotor=i)
+                for point in range(count)]
         else:
-            rotorpot_num = [freq_factor * rpn for rpn in rotorpot_num]
-            rotorpot = ' '.join(['{:.2f}'.format(ei) for ei in rotorpot_num[:species.hir.nrotation // rotorsymm]])
-        rotorpot = '        {}'.format(rotorpot)
+            rotorpot_num = rotorpot_num[:count]
+        rotorpot = '        ' + ' '.join(f'{freq_factor * energy:.2f}' for energy in rotorpot_num)
         if maxen < self.par['free_rotor_thrs']:
             rotortype = 'free'
         return rotorpot, rotortype
@@ -979,10 +978,7 @@ class MESS:
 
     def nrotorpot(self, species, rot): 
         rotorsymm = self.rotorsymm(species, rot)
-        if species.hir.nrotation // rotorsymm > 2:
-            return species.hir.nrotation // rotorsymm
-        else:
-            return species.hir.nrotation // rotorsymm + 1
+        return max(3, int(np.ceil(species.hir.nrotation / rotorsymm)))
 
     def make_rotors(self, species, freq_factor, norot=None, bless=False):
         rotors = []

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -351,6 +351,11 @@ class Optimize:
                         if self.shigh == 0.5:  # the top one was tested already and was ok
                             stati = [0] * len(self.species.conformer_index)
                             for ci, conindx in enumerate(self.species.conformer_index):
+                                if conindx < 0:
+                                    # A terminal failure is not a job index;
+                                    # log_name would resolve it to the parent.
+                                    stati[ci] = 1
+                                    continue
                                 status = self.qc.check_qc(self.log_name(1, conf=conindx))
                                 if status == 'error':
                                     stati[ci] = 1

--- a/kinbot/optimize.py
+++ b/kinbot/optimize.py
@@ -139,6 +139,8 @@ class Optimize:
         while 1:
             # do the conformational search
             if self.par['conformer_search'] == 1:
+                l0_conformer_search = (self.par['semi_emp_conformer_search'] == 1
+                                       and not self.species.wellorts)
                 if self.scycconf == -1 and self.sconf == -1:
                     logger.info('\tStarting conformational search of '
                                 f'{self.name}')
@@ -164,7 +166,7 @@ class Optimize:
                         # ring conf search is finished
                         self.scycconf = 1
                 # first do an semi empirical optimization if requested by the user
-                if self.par['semi_emp_conformer_search'] == 1:
+                if l0_conformer_search:
                     if self.ssemi_empconf == -1 and self.scycconf == 1:
                         logger.info('\tSemi-empirical conformer search is starting '
                                     f'for {self.name}')
@@ -195,7 +197,7 @@ class Optimize:
                         # open chain part has not started yet
                         # if semi empirical conformer were searched for, start from those,
                         # else start from cyclic conformers
-                        if self.par['semi_emp_conformer_search'] == 1:
+                        if l0_conformer_search:
                             valid = [(geom, energy) for geom, energy, status in zip(
                                 self.semi_emp_conformers, self.semi_emp_energies,
                                 self.semi_emp_valid) if status == 0]

--- a/kinbot/stationary_pt.py
+++ b/kinbot/stationary_pt.py
@@ -718,29 +718,42 @@ class StationaryPoint:
             self.bonds = [self.bond]
         self.dihed = []
         self.dihed_allrot = []
-        hit = 0
 
         if self.natom < 4: return 0
 
-        # a-b-c-d, rotation around b-c
-        for b in range(self.natom):
-            if hit == 1: hit = 0
-            for c in range(b, self.natom):
-                if hit == 1: hit = 0
-                if all([bi[b][c] == 1 for bi in self.bonds]) and self.cycle[b] * self.cycle[c] == 0:
+        # a-b-c-d rotates around b-c; the outer bonds only define the angle.
+        # Keep existing single-bond references and rotor indices first (HIR
+        # restart names use those indices). Then add missing axes, such as
+        # C-N in nitro groups, allowing multiple bonds as outer references.
+        rotors = self.dihed_allrot if findall else self.dihed
+        found_axes = set()
+        for allow_multiple in (False, True):
+            for b in range(self.natom):
+                for c in range(b + 1, self.natom):
+                    if ((b, c) in found_axes
+                            or not all(bi[b][c] == 1 for bi in self.bonds)
+                            or self.cycle[b] * self.cycle[c] != 0):
+                        continue
+                    found = False
                     for a in range(self.natom):
-                        if hit == 1: break
-                        if self.bond[a][b] == 1 and a != c:
-                            for d in range(self.natom):
-                                if hit == 1: break
-                                if self.bond[c][d] == 1 and d != b:
-                                    dihedral_angle, warning = geometry.calc_dihedral(self.geom[a], self.geom[b], self.geom[c], self.geom[d])
-                                    if warning == 0:
-                                        if findall == 0:
-                                            self.dihed.append([a, b, c, d])
-                                            hit = 1 
-                                        else:
-                                            self.dihed_allrot.append([a, b, c, d])
+                        if found and not findall:
+                            break
+                        if (a == c or self.bond[a][b] <= 0
+                                or (not allow_multiple and self.bond[a][b] != 1)):
+                            continue
+                        for d in range(self.natom):
+                            if (d == b or self.bond[c][d] <= 0
+                                    or (not allow_multiple and self.bond[c][d] != 1)):
+                                continue
+                            _, warning = geometry.calc_dihedral(
+                                self.geom[a], self.geom[b], self.geom[c], self.geom[d])
+                            if warning == 0:
+                                rotors.append([a, b, c, d])
+                                found = True
+                                if not findall:
+                                    break
+                    if found:
+                        found_axes.add((b, c))
 
         return 0
 

--- a/tests/test_conformer_validation.py
+++ b/tests/test_conformer_validation.py
@@ -1,0 +1,86 @@
+"""Exercise completed conformer records without submitting QC calculations."""
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+from unittest.mock import Mock
+
+from ase.build import molecule
+
+from kinbot import constants
+from kinbot.conformers import Conformers
+from kinbot.parameters import Parameters
+from kinbot.qc import QuantumChemistry
+from kinbot.stationary_pt import StationaryPoint
+
+
+class TestConformerValidation(unittest.TestCase):
+    def setUp(self):
+        directory = TemporaryDirectory()
+        self.addCleanup(directory.cleanup)
+        self.addCleanup(os.chdir, Path.cwd())
+        os.chdir(directory.name)
+        Path('conf').mkdir()
+        Path('input.json').write_text('{"barrier_threshold": 50}')
+        self.par = Parameters('input.json', show_warnings=False).par
+        atoms = molecule('CH3CH2OH')
+        self.species = StationaryPoint('ethanol', 0, 1,
+            atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+        self.species.characterize()
+        self.species.name = str(self.species.chemid)
+        self.qc = QuantumChemistry(self.par)
+        self.qc.qc = 'fc'  # Read database results without native log copying.
+        self.qc.check_qc = Mock(return_value='normal')
+        self.atoms = atoms
+        self.nfreq = 3 * len(atoms) - 6
+
+    def record(self, name, energy, frequencies, zpe=0.):
+        self.qc.db.write(self.atoms, name=name, data={
+            'energy': energy / constants.EVtoHARTREE, 'zpe': zpe,
+            'frequencies': frequencies, 'status': 'normal'})
+
+    def check_pair(self, wellorts, higher_frequencies):
+        self.species.wellorts = wellorts
+        if wellorts:
+            self.species.name = 'ethanol_ts_fixture'
+        parent = self.species.name if wellorts else f'{self.species.name}_well'
+        valid = ([-1000.] + [100.] * (self.nfreq - 1)
+                 if wellorts else [100.] * self.nfreq)
+        self.species.freq = valid
+        search = Conformers(self.species, self.par, self.qc)
+        self.record(parent, -100., valid)
+        self.record(search.get_job_name(0), -100., valid)
+        self.record(search.get_job_name(1), -99.999, higher_frequencies)
+        search.conf = 2
+        result = search.check_conformers()
+        return search, result
+
+    def test_higher_well_with_imaginary_frequency_is_excluded_before_population(self):
+        search, result = self.check_pair(0, [-100.] + [100.] * (self.nfreq - 1))
+        self.assertEqual(result[7], [0, 1])
+        self.assertEqual(search.find_unique(*result[4:8], temp=300., boltz=.001)[-1], [0])
+
+    def test_ts_requires_one_reaction_coordinate_with_existing_soft_mode_allowance(self):
+        for initial, accepted in [([], False), ([-1000.], True),
+                                  ([-1000., -100.], False),
+                                  ([-1000., -20.], True),
+                                  ([-1000., -20., -10.], False)]:
+            with self.subTest(initial=initial):
+                frequencies = initial + [100.] * (self.nfreq - len(initial))
+                _, result = self.check_pair(1, frequencies)
+                self.assertEqual(result[7], [0, 0 if accepted else 1])
+
+    def test_empty_and_nonfinite_spectra_are_excluded(self):
+        for wellorts in (0, 1):
+            for frequencies in ([], [float('nan')] * self.nfreq):
+                with self.subTest(wellorts=wellorts, frequencies=frequencies):
+                    _, result = self.check_pair(wellorts, frequencies)
+                    self.assertEqual(result[7], [0, 1])
+
+    def test_existing_small_imaginary_well_mode_is_still_allowed(self):
+        _, result = self.check_pair(0, [-20.] + [100.] * (self.nfreq - 1))
+        self.assertEqual(result[7], [0, 0])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_conformer_validation.py
+++ b/tests/test_conformer_validation.py
@@ -82,5 +82,24 @@ class TestConformerValidation(unittest.TestCase):
         self.assertEqual(result[7], [0, 0])
 
 
+    def test_parent_fallback_returns_electronic_hartree_for_both_paths(self):
+        parent = f'{self.species.name}_well'
+        self.record(parent, -100., [100.] * self.nfreq, zpe=.1)
+        # The all-failed path retains the existing native-output copy.
+        self.qc.qc = 'gauss'
+        Path(parent + '.log').write_text('completed parent output')
+        for all_failed in (True, False):
+            with self.subTest(all_failed=all_failed):
+                search = Conformers(self.species, self.par, self.qc)
+                search.conf, search.conf_status = 1, [int(all_failed)]
+                if not all_failed:
+                    self.record(search.get_job_name(0), -99., [100.] * self.nfreq, zpe=.1)
+                result = search.check_conformers()
+                self.assertEqual(search.selected_job, parent)
+                self.assertAlmostEqual(result[3], -100.)
+                if not all_failed:
+                    self.assertAlmostEqual(result[5][0], -98.9)  # E + ZPE stays separate.
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -192,5 +192,38 @@ class TestSemiEmpiricalConformers(unittest.TestCase):
 
 
 
+class TestHighLevelConformerPolling(unittest.TestCase):
+    def test_failed_conformer_is_terminal_while_another_is_running(self):
+        optimization = Optimize.__new__(Optimize)
+        optimization.species = SimpleNamespace(
+            conformer_index=[0, 1], wellorts=1, freq=[-100., 100.])
+        optimization.name = 'fixture'
+        optimization.par = {
+            'conformer_search': 0, 'high_level': 1, 'rotation_restart': 0,
+            'rotor_scan': 0, 'multi_conf_tst': 1, 'L3_calc': 0,
+        }
+        optimization.shigh = .5
+        optimization.shir = -1
+        optimization.restart = 0
+        optimization.wait = 0
+        optimization.just_high = False
+        statuses = {'fixture_0000_high': 'error',
+                    'fixture_0001_high': 'running', 'fixture_high': 'normal'}
+        optimization.qc = SimpleNamespace(check_qc=Mock(side_effect=statuses.get))
+        optimization.compare_structures = Mock()
+        optimization.do_optimization()
+        self.assertEqual(optimization.species.conformer_index, [-999, 1])
+        optimization.qc.check_qc.reset_mock()
+        optimization.do_optimization()
+        optimization.qc.check_qc.assert_called_once_with('fixture_0001_high')
+        optimization.compare_structures.assert_not_called()
+        statuses['fixture_0001_high'] = 'normal'
+        with patch('kinbot.optimize.symmetry.calculate_symmetry'):
+            optimization.do_optimization()
+        self.assertEqual(optimization.shigh, 1)
+        optimization.compare_structures.assert_called_once_with(conf=1)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -164,5 +164,33 @@ class TestSemiEmpiricalConformers(unittest.TestCase):
 
 
 
+    def test_saddle_skips_l0_and_polls_l1_without_l0_seed_results(self):
+        self.species.wellorts = 1
+        self.regular.generate_conformers.return_value = 0
+        for _ in range(2):
+            self.optimization.do_optimization()
+        self.semi.generate_conformers.assert_not_called()
+        self.semi.check_conformers.assert_not_called()
+        self.assertEqual(self.optimization.ssemi_empconf, 1)
+        self.regular.generate_conformers.assert_called_once()
+        self.assertEqual(self.regular.generate_conformers.call_args.args[0], 0)
+        self.assertEqual(self.regular.check_conformers.call_count, 2)
+
+
+    def test_ring_saddle_keeps_ring_sampling_then_proceeds_directly_to_l1(self):
+        self.species.wellorts = 1
+        self.species.cycle_chain = [[0, 1, 2, 3]]
+        self.regular.generate_conformers.return_value = 0
+        self.regular.check_ring_conformers.side_effect = [(0, []), (1, [self.geom])]
+        self.optimization.do_optimization()
+        self.regular.generate_conformers.assert_not_called()
+        self.optimization.do_optimization()
+        self.regular.generate_ring_conformers.assert_called_once()
+        self.semi.generate_conformers.assert_not_called()
+        self.regular.generate_conformers.assert_called_once()
+        self.assertEqual(self.regular.generate_conformers.call_args.args[0], 0)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_hindered_rotors.py
+++ b/tests/test_hindered_rotors.py
@@ -83,6 +83,26 @@ class TestHIRProfile(unittest.TestCase):
 
 
 class TestHIRFits(unittest.TestCase):
+    def test_mess_interpolates_uniform_points_within_the_rotor_symmetry_period(self):
+        writer = MESS.__new__(MESS)
+        writer.par = {'free_rotor_thrs': .1}
+        rot = [0, 1, 2, 3]
+        for nrotation, sigma in ((12, 6), (11, 2), (12, 3)):
+            with self.subTest(nrotation=nrotation, sigma=sigma):
+                angles = np.arange(nrotation) * 2 * np.pi / nrotation
+                energies = 2 * (1 - np.cos(sigma * angles))
+                point = SimpleNamespace(sigma_int=np.ones((4, 4), dtype=int),
+                    hir=SimpleNamespace(nrotation=nrotation,
+                        hir_energies=[(-100. + energies / constants.AUtoKCAL).tolist()],
+                        get_fit_value=lambda angle, rotor: 2 * (1 - np.cos(sigma * angle))))
+                point.sigma_int[1, 2] = sigma
+                potential, _ = writer.make_rotorpot(point, 0, rot, 1.)
+                count = writer.nrotorpot(point, rot)
+                expected = 2 * (1 - np.cos(2 * np.pi * np.arange(count) / count))
+                np.testing.assert_allclose(list(map(float, potential.split())), expected, atol=.005)
+                self.assertGreaterEqual(count, 3)
+
+
 
 
 
@@ -143,7 +163,7 @@ class TestHIRFits(unittest.TestCase):
         writer.rotorsymm = lambda species, rotor: 6
         potential, kind = writer.make_rotorpot(hir.species, 0, hir.species.dihed[0], 1.)
         self.assertEqual(kind, 'hindered')
-        self.assertEqual(float(potential.split()[1]), round(1 - np.cos(np.pi / 12), 2))
+        self.assertEqual(float(potential.split()[1]), round(1 - np.cos(np.pi / 9), 2))
 
 
 class TestHIRStatus(unittest.TestCase):

--- a/tests/test_rotor_detection.py
+++ b/tests/test_rotor_detection.py
@@ -1,0 +1,148 @@
+"""Rotating bonds stay single; torsion reference bonds need not be single."""
+from types import SimpleNamespace
+import unittest
+
+import numpy as np
+from ase import Atoms
+from ase.build import molecule
+from scipy.linalg import null_space
+
+from kinbot import constants, frequencies, symmetry
+from kinbot.hindered_rotors import HIR
+from kinbot.stationary_pt import StationaryPoint
+
+
+def point(atoms, mult=1, order=None):
+    if order is not None:
+        atoms = atoms[order]
+    species = StationaryPoint('rotor_detection', 0, mult,
+        atom=atoms.get_chemical_symbols(), geom=atoms.positions)
+    species.characterize()
+    return species
+
+
+class TestRotorDetection(unittest.TestCase):
+    def test_nitro_nitroso_and_acyl_rotors_in_both_axis_orders(self):
+        for name, mult in [('CH3NO2', 1), ('CH3NO', 1), ('CH3CO', 2)]:
+            # Detection fixture only: remove one O for the nitroso group.
+            # This is not an optimized nitrosomethane geometry.
+            atoms = (molecule('CH3NO2')[:-1]
+                     if name == 'CH3NO' else molecule(name))
+            rng = np.random.default_rng(173)
+            orders = [np.arange(len(atoms)), np.arange(len(atoms))[::-1]]
+            orders += [rng.permutation(len(atoms)) for _ in range(12)]
+            for order in orders:
+                with self.subTest(name=name, order=order.tolist()):
+                    species = point(atoms, mult, order)
+                    self.assertEqual(len(species.dihed), 1)
+                    a, b, c, d = species.dihed[0]
+                    self.assertEqual(sorted([species.atom[b], species.atom[c]]),
+                                     ['C', 'C'] if name == 'CH3CO' else ['C', 'N'])
+                    self.assertEqual(sorted([species.bond[a, b], species.bond[c, d]]), [1, 2])
+                    self.assertTrue(all(bond[b, c] == 1 for bond in species.bonds))
+                    # Finding a HIR rotor must not sample symmetry-equivalent
+                    # methyl orientations as extra conformers.
+                    self.assertEqual(species.conf_dihed, [])
+
+    def test_redundant_nitro_references_do_not_duplicate_the_axis(self):
+        species = point(molecule('CH3NO2'))
+        graph, identity = species.bond.copy(), species.chemid
+        symmetry.calculate_symmetry(species)
+        self.assertEqual(species.sigma_int[0][1], 6)
+        species.find_dihedral(findall=1)
+        self.assertEqual(len(species.dihed_allrot), 6)  # three H times two O
+        self.assertEqual({tuple(r[1:3]) for r in species.dihed_allrot}, {(0, 1)})
+        species.find_dihedral()
+        self.assertEqual(len(species.dihed), 1)
+        np.testing.assert_array_equal(species.bond, graph)
+        self.assertEqual(species.chemid, identity)
+
+    def test_existing_rotor_references_remain_unchanged(self):
+        expected = {
+            'CH3OH': [[2, 0, 1, 3]],
+            'CH3CH2OH': [[6, 0, 1, 2], [0, 1, 2, 3]],
+            'CH3COCH3': [[3, 1, 2, 4], [2, 1, 3, 5]],
+            'CH3CHO': [[2, 1, 3, 4]],
+            'C2H6': [[2, 0, 1, 5]],
+        }
+        for name, rotors in expected.items():
+            with self.subTest(name=name):
+                self.assertEqual(point(molecule(name)).dihed, rotors)
+
+    def test_new_axis_is_appended_without_renumbering_existing_rotors(self):
+        # Fixed nitroethane geometry (RDKit/MMFF, seed 71); no RDKit runtime
+        # dependency. Reverse the atoms so the missing C-N axis sorts first.
+        atoms = Atoms('CCNOOHHHHH', positions=[
+            [1.06018423, -.40985387, .02750706],
+            [-.03570052, .62843464, -.08975162],
+            [-1.35865392, -.05859812, .04912401],
+            [-1.82204219, -.16237203, 1.19162857],
+            [-1.88726904, -.47739185, -.98817595],
+            [.97245909, -1.17262515, -.75381576],
+            [2.04182915, .06402358, -.07034597],
+            [1.02482634, -.9196928, .99642097],
+            [.02859292, 1.38158493, .70127792],
+            [-.02422606, 1.12649068, -1.06386922]])
+        species = point(atoms, order=np.arange(len(atoms))[::-1])
+        self.assertEqual([r[1:3] for r in species.dihed], [[8, 9], [7, 8]])
+        self.assertEqual(species.dihed[0], [0, 8, 9, 2])
+
+    def test_multiple_ring_and_linear_axes_stay_excluded(self):
+        for name in ['C2H4', 'C2H2', 'C6H6', 'C3H6_D3h', 'CH3CN']:
+            with self.subTest(name=name):
+                self.assertEqual(point(molecule(name)).dihed, [])
+        species = point(molecule('CH3NO2'))
+        other_resonance = species.bond.copy()
+        other_resonance[0, 1] = other_resonance[1, 0] = 2
+        species.bonds.append(other_resonance)
+        species.find_dihedral()
+        self.assertEqual(species.dihed, [])
+
+    def test_nitro_hir_geometries_preserve_both_fragments(self):
+        species = point(molecule('CH3NO2'))
+        self.assertEqual(len(species.dihed), 1)
+        captures = []
+
+        def capture(species, xyz, rotor, angle, fix, rigid):
+            captures.append(np.asarray(xyz).copy())
+            return f'captured_{rotor}_{angle}'
+
+        hir = HIR(species, SimpleNamespace(qc='gauss', qc_hir=capture),
+                  {'nrotation': 12, 'plot_hir_profiles': False, 'rotor_0_test': True})
+        hir.generate_hir_geoms(species.geom, False)
+        self.assertEqual(len(captures), 12)
+        groups = frequencies.partition(species, species.dihed[0], species.natom)
+        self.assertEqual(sorted(map(len, groups)), [3, 4])
+        angles = []
+        for xyz in captures:
+            self.assertTrue(np.isfinite(xyz).all())
+            bonded = np.argwhere(np.triu(species.bond) > 0)
+            np.testing.assert_allclose(
+                [np.linalg.norm(xyz[a] - xyz[b]) for a, b in bonded],
+                [np.linalg.norm(species.geom[a] - species.geom[b]) for a, b in bonded],
+                atol=1e-7)
+            for group in groups:
+                old, new = species.geom[group], xyz[group]
+                np.testing.assert_allclose(np.linalg.norm(old[:, None]-old[None, :], axis=-1),
+                                           np.linalg.norm(new[:, None]-new[None, :], axis=-1), atol=1e-7)
+            angles.append(Atoms(species.atom, positions=xyz).get_dihedral(*species.dihed[0]))
+        np.testing.assert_allclose(np.abs(np.diff(np.unwrap(np.radians(angles))))*180/np.pi,
+                                   30., atol=1e-7)
+
+    def test_nitro_projection_removes_one_mode(self):
+        species = point(molecule('CH3NO2'))
+        mass = np.array([constants.exact_mass[a] for a in species.atom])
+        xyz = species.geom - np.average(species.geom, axis=0, weights=mass)
+        rigid = [np.tile(v, (species.natom, 1))*np.sqrt(mass[:, None]) for v in np.eye(3)]
+        rigid += [np.cross(xyz, v)*np.sqrt(mass[:, None]) for v in np.eye(3)]
+        basis = null_space(np.array(rigid).reshape(6, -1))
+        # Analytic Hessian with known positive eigenvalues in the physical
+        # vibrational space; this is not a computed nitromethane spectrum.
+        weighted = .01 * (basis @ basis.T)
+        hess = weighted*np.sqrt(np.outer(np.repeat(mass, 3), np.repeat(mass, 3)))
+        raw, reduced = frequencies.get_frequencies(species, hess, species.geom)
+        self.assertEqual((len(raw), len(reduced)), (15, 14))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_selected_hessian.py
+++ b/tests/test_selected_hessian.py
@@ -204,6 +204,38 @@ class TestSelectedHessian(unittest.TestCase):
         self.assertNotIn('Rotor Free', text)
         self.assertIn('kept as a harmonic oscillator', text)
 
+    def test_failed_recovery_without_hir_is_documented_in_mess_output(self):
+        self.record(self.job)
+        load_calculation_record(self.species, self.qc, self.job)
+        opt = self.optimization()
+        self.assertIsNone(self.species.hir)
+        with patch.object(self.qc, 'read_qc_hess', return_value=[]), \
+                patch.object(self.qc, 'qc_freq', return_value='failed_recovery'), \
+                patch.object(self.qc, 'check_qc', return_value='error'), \
+                self.assertLogs('KinBot', level='WARNING'):
+            opt.do_optimization()
+        self.assertIsNone(self.species.hir)
+        self.assertEqual(self.species.freq, self.freq)
+        self.assertEqual(self.species.reduced_freqs, self.freq)
+        self.assertEqual(self.species.source_job, self.job)
+        self.assertAlmostEqual(self.species.energy, -100.)
+        for pes in (0, 1):
+            with self.subTest(pes=pes):
+                self.par['pes'] = pes
+                writer = MESS(self.par, self.species)
+                writer.well_names[self.species.chemid] = 'W1'
+                text = writer.write_well(self.species, 0., 1., 0)
+                self.assertEqual(Path(f'{self.species.chemid}_0000.mess').read_text(), text)
+                self.assertNotIn('Rotor Hindered', text)
+                self.assertNotIn('Rotor Free', text)
+                self.assertRegex(text, r'Frequencies\[1/cm\]\s+12\b')
+                self.assertTrue(self.species.dihed)
+                for rot in self.species.dihed:
+                    self.assertIn(
+                        f'! Rotor about atoms {rot[1] + 1}-{rot[2] + 1} '
+                        'kept as a harmonic oscillator: no usable selected-geometry '
+                        'Hessian; hindered rotors omitted', text)
+
     def test_invalid_recovery_results_do_not_replace_selected_properties(self):
         self.record(self.job)
         for failure in ('missing_record', 'changed_geometry', 'missing_hessian',


### PR DESCRIPTION
This PR contains seven separate fixes, each with regression coverage:
- Validate all L1 conformers before MC-TST population filtering. Previously, a higher-energy conformer could bypass frequency checks because it never became the lowest-energy structure. Wells and TS conformers now undergo their respective existing imaginary-frequency checks before acceptance.
- Restrict preliminary conformer searches to wells. Add the wellorts guard requested during the previous review, preventing the preliminary semi-empirical stage from running on transition states.
- Correct angular spacing in MESS rotor potentials. MESS interprets potential values as equally spaced over the symmetry period. For a sixfold rotor, the previous code supplied values at 0°, 15° and 30°, which MESS interpreted as 0°, 20° and 40°. The writer now evaluates the existing Fourier fit at the required angles when necessary. The underlying QC scan grid is unchanged.
- Return consistent energies from conformer fallbacks. When all sampled conformers fail, or the parent structure is selected by the existing consistency check, return electronic energy in Hartree. Previously, these paths could return an eV value or include ZPE unexpectedly.
- Skip failed L2 conformers during subsequent polling. A failed conformer’s -999 marker could be interpreted as a request for the representative calculation while other conformers were still running. Failed entries are now treated as finished.
- Detect nitro, nitroso and acyl rotors. Allow a multiple-bonded outer atom to define the dihedral angle while retaining the existing restrictions on the central rotation bond. This restores rotors previously missed in these groups.
- Document harmonic fallback in MESS input. When Hessian recovery fails before an HIR object is created, emit a ! comment explaining why rotors were omitted. The accepted harmonic frequencies and energies remain unchanged.